### PR TITLE
fix: replace process.env with ctx.env in server.ts

### DIFF
--- a/src/sdk/server.ts
+++ b/src/sdk/server.ts
@@ -59,9 +59,9 @@ export async function createPlugin<TConfig = unknown, TEnv = unknown, TSupported
 
     let env: TEnv;
     if (pluginOptions.envSchema) {
-      env = Value.Decode(pluginOptions.envSchema, process.env);
+      env = Value.Decode(pluginOptions.envSchema, ctx.env);
     } else {
-      env = process.env as TEnv;
+      env = ctx.env as TEnv;
     }
 
     const context: Context<TConfig, TEnv, TSupportedEvents> = {


### PR DESCRIPTION
Modified the environment variable reference to use ctx.env for consistency.
https://hono.dev/docs/helpers/adapter#env

Relates to #138

@whilefoo rfc

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
