### PR TITLE
fix: skip posting help comment when no commands found

### DIFF
--- a/src/github/handlers/help-command.ts
+++ b/src/github/handlers/help-command.ts
@@ -27,12 +27,16 @@ export async function postHelpCommand(context: GitHubContext<"issue_comment.crea
     const { plugin } = pluginElement.uses[0];
     commands.push(...(await parseCommandsFromManifest(context, plugin)));
   }
-  await context.octokit.rest.issues.createComment({
-    body: comments.concat(commands.sort()).join("\n"),
-    issue_number: context.payload.issue.number,
-    owner: context.payload.repository.owner.login,
-    repo: context.payload.repository.name,
-  });
+  if (!commands.length) {
+    console.warn("No commands found, will not post the help command message.");
+  } else {
+    await context.octokit.rest.issues.createComment({
+      body: comments.concat(commands.sort()).join("\n"),
+      issue_number: context.payload.issue.number,
+      owner: context.payload.repository.owner.login,
+      repo: context.payload.repository.name,
+    });
+  }
 }
 
 /**

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -134,4 +134,61 @@ describe("Event related tests", () => {
       ],
     ]);
   });
+  it("Should not post the help menu when /help command if there is no available command", async () => {
+    const issues = {
+      createComment(params?: RestEndpointMethodTypes["issues"]["createComment"]["parameters"]) {
+        return params;
+      },
+    };
+    const spy = jest.spyOn(issues, "createComment");
+    const getContent = jest.fn((params?: RestEndpointMethodTypes["repos"]["getContent"]["parameters"]) => {
+      if (params?.path === CONFIG_FULL_PATH) {
+        return {
+          data: `
+                    plugins:
+                      - name: "Some Action plugin"
+                        uses:
+                          - id: plugin-B
+                            plugin: ubiquity-os/plugin-b
+                    `,
+        };
+      } else if (params?.path === "manifest.json") {
+        return {
+          data: {
+            content: btoa(
+              JSON.stringify({
+                name: "plugin",
+              })
+            ),
+          },
+        };
+      } else {
+        throw new Error("Not found");
+      }
+    });
+    await issueCommentCreated({
+      id: "",
+      key: "issue_comment.created",
+      octokit: {
+        rest: {
+          issues,
+          repos: {
+            getContent: getContent,
+          },
+        },
+      },
+      eventHandler: eventHandler,
+      payload: {
+        repository: {
+          owner: { login: "ubiquity" },
+          name,
+        },
+        issue: { number: 1 },
+        comment: {
+          body: "/help",
+        },
+      } as unknown as GitHubContext<"issue_comment.created">["payload"],
+    } as unknown as GitHubContext);
+    expect(spy).not.toBeCalled();
+  });
 });

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -82,7 +82,7 @@ describe("Event related tests", () => {
           data: {
             content: btoa(
               JSON.stringify({
-                name: "plugin",
+                name: "plugin A",
                 commands: {
                   action: {
                     description: "action",
@@ -148,8 +148,8 @@ describe("Event related tests", () => {
                     plugins:
                       - name: "Some Action plugin"
                         uses:
-                          - id: plugin-B
-                            plugin: ubiquity-os/plugin-b
+                          - id: plugin-c
+                            plugin: ubiquity-os/plugin-c
                     `,
         };
       } else if (params?.path === "manifest.json") {
@@ -157,7 +157,7 @@ describe("Event related tests", () => {
           data: {
             content: btoa(
               JSON.stringify({
-                name: "plugin",
+                name: "plugin c",
               })
             ),
           },


### PR DESCRIPTION
Added a check to ensure no comment is posted if commands are empty. Note: there can be plugins enabled but without any command, which will result in the `help` command being skipped as well.

Resolves #152
QA: https://github.com/Meniole/ubiquity-os-kernel/issues/18#issuecomment-2445752793

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
