### PR TITLE
Changed the execution to be handled by the context

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,7 +8,7 @@ import { WebhookEventName } from "@octokit/webhooks-types";
 import OpenAI from "openai";
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     try {
       validateEnv(env);
       const eventName = getEventName(request);
@@ -26,7 +26,7 @@ export default {
         openAiClient,
       });
       bindHandlers(eventHandler);
-      await eventHandler.webhooks.verifyAndReceive({ id, name: eventName, payload: await request.text(), signature: signatureSha256 });
+      ctx.waitUntil(eventHandler.webhooks.verifyAndReceive({ id, name: eventName, payload: await request.text(), signature: signatureSha256 }));
       return new Response("ok\n", { status: 200, headers: { "content-type": "text/plain" } });
     } catch (error) {
       return handleUncaughtError(error);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -61,14 +61,21 @@ describe("Worker tests", () => {
   it("Should fail on missing env variables", async () => {
     const req = new Request("http://localhost:8080");
     const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => jest.fn());
-    const res = await worker.fetch(req, {
-      ENVIRONMENT: "production",
-      APP_WEBHOOK_SECRET: "",
-      APP_ID: "",
-      APP_PRIVATE_KEY: "",
-      PLUGIN_CHAIN_STATE: {} as KVNamespace,
-      OPENAI_API_KEY: "token",
-    });
+    const res = await worker.fetch(
+      req,
+      {
+        ENVIRONMENT: "production",
+        APP_WEBHOOK_SECRET: "",
+        APP_ID: "",
+        APP_PRIVATE_KEY: "",
+        PLUGIN_CHAIN_STATE: {} as KVNamespace,
+        OPENAI_API_KEY: "token",
+      },
+      {
+        waitUntil: function () {},
+        passThroughOnException: function () {},
+      }
+    );
     expect(res.status).toEqual(500);
     consoleSpy.mockReset();
   });


### PR DESCRIPTION
Relates to #195

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
