### PR TITLE
fix: the default values for skipBotEvents and ubiquity:listeners is no longer overridden

### DIFF
--- a/src/github/types/plugin-configuration.ts
+++ b/src/github/types/plugin-configuration.ts
@@ -60,7 +60,7 @@ const pluginChainSchema = T.Array(
     plugin: githubPluginType(),
     with: T.Record(T.String(), T.Unknown(), { default: {} }),
     runsOn: T.Array(emitterType, { default: [] }),
-    skipBotEvents: T.Boolean({ default: true }),
+    skipBotEvents: T.Optional(T.Boolean({ default: true })),
   }),
   { minItems: 1, default: [] }
 );

--- a/src/github/utils/config.ts
+++ b/src/github/utils/config.ts
@@ -94,8 +94,12 @@ export async function getConfig(context: GitHubContext): Promise<PluginConfigura
   for (const plugin of mergedConfiguration.plugins) {
     const manifest = await getManifest(context, plugin.uses[0].plugin);
     if (manifest) {
-      plugin.uses[0].runsOn = manifest["ubiquity:listeners"] ?? [];
-      plugin.uses[0].skipBotEvents = manifest.skipBotEvents ?? plugin.uses[0].skipBotEvents;
+      if (!plugin.uses[0].runsOn.length) {
+        plugin.uses[0].runsOn = manifest["ubiquity:listeners"] ?? [];
+      }
+      if (manifest.skipBotEvents !== undefined) {
+        plugin.uses[0].skipBotEvents = manifest.skipBotEvents ?? plugin.uses[0].skipBotEvents;
+      }
     }
   }
   return mergedConfiguration;

--- a/src/github/utils/config.ts
+++ b/src/github/utils/config.ts
@@ -93,9 +93,8 @@ export async function getConfig(context: GitHubContext): Promise<PluginConfigura
 
   for (const plugin of mergedConfiguration.plugins) {
     const manifest = await getManifest(context, plugin.uses[0].plugin);
-    if (manifest) {
+    if (manifest && !plugin.uses[0].runsOn.length) {
       plugin.uses[0].runsOn = manifest["ubiquity:listeners"] ?? [];
-      plugin.uses[0].skipBotEvents = manifest.skipBotEvents ?? true;
     }
   }
   return mergedConfiguration;

--- a/src/github/utils/config.ts
+++ b/src/github/utils/config.ts
@@ -93,8 +93,9 @@ export async function getConfig(context: GitHubContext): Promise<PluginConfigura
 
   for (const plugin of mergedConfiguration.plugins) {
     const manifest = await getManifest(context, plugin.uses[0].plugin);
-    if (manifest && !plugin.uses[0].runsOn.length) {
+    if (manifest) {
       plugin.uses[0].runsOn = manifest["ubiquity:listeners"] ?? [];
+      plugin.uses[0].skipBotEvents = manifest.skipBotEvents ?? plugin.uses[0].skipBotEvents;
     }
   }
   return mergedConfiguration;

--- a/src/github/utils/config.ts
+++ b/src/github/utils/config.ts
@@ -97,8 +97,8 @@ export async function getConfig(context: GitHubContext): Promise<PluginConfigura
       if (!plugin.uses[0].runsOn.length) {
         plugin.uses[0].runsOn = manifest["ubiquity:listeners"] ?? [];
       }
-      if (manifest.skipBotEvents !== undefined) {
-        plugin.uses[0].skipBotEvents = manifest.skipBotEvents ?? plugin.uses[0].skipBotEvents;
+      if (plugin.uses[0].skipBotEvents === undefined) {
+        plugin.uses[0].skipBotEvents = manifest.skipBotEvents ?? true;
       }
     }
   }

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -37,9 +37,6 @@ app.post("/", async (ctx: Context) => {
       pluginChainState: new EmptyStore(),
       openAiClient,
     });
-    eventHandler.onAny(() => {
-      console.log(`Received POST from ${ctx.req.url}`);
-    });
     bindHandlers(eventHandler);
 
     // if running in Cloudflare Worker, handle the webhook in the background and return a response immediately

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -37,6 +37,9 @@ app.post("/", async (ctx: Context) => {
       pluginChainState: new EmptyStore(),
       openAiClient,
     });
+    eventHandler.onAny(() => {
+      console.log(`Received POST from ${ctx.req.url}`);
+    });
     bindHandlers(eventHandler);
 
     // if running in Cloudflare Worker, handle the webhook in the background and return a response immediately

--- a/tests/configuration.test.ts
+++ b/tests/configuration.test.ts
@@ -54,6 +54,7 @@ describe("Configuration tests", () => {
         plugins:
           - uses:
             - plugin: ubiquity/user-activity-watcher:compute.yml@fork/pull/1
+              skipBotEvents: false
               with:
                 settings1: 'enabled'`;
       } else {
@@ -187,7 +188,6 @@ describe("Configuration tests", () => {
                 "ubiquity:example": "/command"
               }
             },
-            "skipBotEvents": false
           }
           `;
       } else if (args.path === CONFIG_FULL_PATH) {
@@ -195,6 +195,7 @@ describe("Configuration tests", () => {
         plugins:
           - uses:
             - plugin: ubiquity/test-plugin
+              skipBotEvents: false
               with:
                 settings1: 'enabled'`;
       } else {

--- a/tests/configuration.test.ts
+++ b/tests/configuration.test.ts
@@ -188,6 +188,7 @@ describe("Configuration tests", () => {
                 "ubiquity:example": "/command"
               }
             },
+            "skipBotEvents": true
           }
           `;
       } else if (args.path === CONFIG_FULL_PATH) {


### PR DESCRIPTION
Resolves #232
QA:
- [daemon disqualifier properly sending a message on assign](https://github.com/Meniole/daemon-merging/issues/23)
- [daemon merging running on assign](https://github.com/Meniole/daemon-merging/issues/22)
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
