### PR TITLE
fix: handle missing plugins config in routers

### DIFF
--- a/src/github/handlers/issue-comment-created.ts
+++ b/src/github/handlers/issue-comment-created.ts
@@ -141,6 +141,12 @@ export default async function issueCommentCreated(context: GitHubContext<"issue_
   }
 
   if (afterMention !== null) {
+    // Users often write "@ubiquityos help" (without a leading slash). Treat it as a help command
+    // instead of routing, so we don't depend on a valid plugins config to provide basic guidance.
+    if (/^help\b/i.test(afterMention)) {
+      await postHelpCommand(context);
+      return;
+    }
     if (context.payload.comment.user?.type === "User") {
       await addReactionEyes(context);
     }
@@ -254,7 +260,7 @@ async function dispatchSlashCommand(context: GitHubContext<"issue_comment.create
   const isBotAuthor = context.payload.comment.user?.type !== "User";
   const pluginsWithManifest: { target: string | GithubPlugin; settings: (typeof config.plugins)[string]; manifest: Manifest }[] = [];
 
-  for (const [pluginKey, pluginSettings] of Object.entries(config.plugins)) {
+  for (const [pluginKey, pluginSettings] of Object.entries(config.plugins ?? {})) {
     let target: string | GithubPlugin;
     try {
       target = parsePluginIdentifier(pluginKey);
@@ -448,7 +454,7 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
   const pluginsWithManifest: { target: string | GithubPlugin; settings: (typeof config.plugins)[string]; manifest: Manifest }[] = [];
   const manifests: Manifest[] = [];
 
-  for (const [pluginKey, pluginSettings] of Object.entries(config.plugins)) {
+  for (const [pluginKey, pluginSettings] of Object.entries(config.plugins ?? {})) {
     let target: string | GithubPlugin;
     try {
       target = parsePluginIdentifier(pluginKey);

--- a/src/github/handlers/pull-request-review-comment-created.ts
+++ b/src/github/handlers/pull-request-review-comment-created.ts
@@ -250,7 +250,7 @@ export default async function pullRequestReviewCommentCreated(context: GitHubCon
 
   const pluginsWithManifest: { target: string | GithubPlugin; settings: PluginSettings; manifest: Manifest }[] = [];
   const manifests: Manifest[] = [];
-  for (const [pluginKey, pluginSettings] of Object.entries(config.plugins)) {
+  for (const [pluginKey, pluginSettings] of Object.entries(config.plugins ?? {})) {
     let target: string | GithubPlugin;
     try {
       target = parsePluginIdentifier(pluginKey);

--- a/src/github/handlers/push-event.ts
+++ b/src/github/handlers/push-event.ts
@@ -133,7 +133,7 @@ async function checkPluginConfigurations(context: GitHubContext<"push">, config:
   const errors: (YAML.YAMLError | YAMLException | ConfigValidationError)[] = [];
   const doc = rawData ? YAML.parseDocument(rawData) : null;
 
-  for (const [pluginKey, settings] of Object.entries(config.plugins)) {
+  for (const [pluginKey, settings] of Object.entries(config.plugins ?? {})) {
     const pluginIdentifier = parsePluginIdentifier(pluginKey);
     const manifest = await getManifest(context, pluginIdentifier);
     const baseSegments: (string | number)[] = ["plugins", pluginKey];


### PR DESCRIPTION
Fixes #287

- Treats "@ubiquityos help" (no leading slash) as a help command instead of routing
- Guards `config.plugins` iteration across issue comment routing, PR review routing, and push config checks

Tests: `/Users/zhi/.deno/bin/deno task test`