### PR TITLE
fix: add null check for config.plugins in commandRouter

### DIFF
--- a/src/github/handlers/issue-comment-created.ts
+++ b/src/github/handlers/issue-comment-created.ts
@@ -440,8 +440,8 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
   }
 
   const config = await getConfig(context);
-  if (!config) {
-    context.logger.debug("No configuration was found");
+  if (!config || !config.plugins) {
+    context.logger.debug("No configuration or plugins found");
     return;
   }
   const isBotAuthor = context.payload.comment.user?.type !== "User";


### PR DESCRIPTION
## Description

Prevents "Cannot convert undefined or null to object" error when config.plugins is undefined. The commandRouter now gracefully handles missing plugins configuration instead of crashing.

## Changes

- Added null check for config.plugins before calling Object.entries(config.plugins)
- Returns early with debug log if plugins configuration is missing

## Fixes

- Fixes: ubiquity-os/ubiquity-os-kernel#287

---

*Submitted as part of devpool-directory bounty #5926*