### PR TITLE
feat(kernel): prefer dist/<source-ref> plugin artifacts with migration fallback

### DIFF
--- a/src/github/handlers/index.ts
+++ b/src/github/handlers/index.ts
@@ -449,7 +449,7 @@ async function emitKernelPluginErrorEvent({
         eventPayload,
         settings?.with,
         authToken,
-        dispatchTarget.ref,
+        dispatchTarget.sourceRef,
         null
       );
 
@@ -542,7 +542,7 @@ async function emitKernelErrorEvent({
         eventPayload,
         settings?.with,
         authToken,
-        dispatchTarget.ref,
+        dispatchTarget.sourceRef,
         null
       );
 
@@ -722,7 +722,7 @@ async function handleEvent(event: EmitterWebhookEvent, eventHandler: InstanceTyp
     // We wrap the dispatch so a failing plugin doesn't break the whole execution
     try {
       const dispatchTarget = await deps.resolvePluginDispatchTarget({ context, plugin });
-      ref = dispatchTarget.ref;
+      ref = dispatchTarget.sourceRef;
       const inputs = new PluginInput(context.eventHandler, stateId, context.key, event.payload, settings?.with, token, ref, null);
 
       context.logger.debug({ plugin: pluginEntry.key, worker: dispatchTarget.kind === "worker" }, DISPATCH_EVENT_LOG);

--- a/src/github/handlers/issue-comment-created.ts
+++ b/src/github/handlers/issue-comment-created.ts
@@ -298,7 +298,7 @@ async function dispatchSlashCommand(context: GitHubContext<"issue_comment.create
   const stateId = crypto.randomUUID();
   const token = await context.eventHandler.getToken(context.payload.installation.id);
   const dispatchTarget = await resolvePluginDispatchTarget({ context, plugin, manifest: matchedPluginWithManifest.manifest });
-  const inputs = new PluginInput(context.eventHandler, stateId, context.key, context.payload, settings, token, dispatchTarget.ref, command);
+  const inputs = new PluginInput(context.eventHandler, stateId, context.key, context.payload, settings, token, dispatchTarget.sourceRef, command);
 
   context.logger.info({ plugin, worker: dispatchTarget.kind === "worker", command }, "Will dispatch slash command plugin.");
   try {
@@ -601,7 +601,7 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
   const stateId = crypto.randomUUID();
   const token = await context.eventHandler.getToken(context.payload.installation.id);
   const dispatchTarget = await resolvePluginDispatchTarget({ context, plugin, manifest: pluginWithManifest.manifest });
-  const inputs = new PluginInput(context.eventHandler, stateId, context.key, context.payload, settings, token, dispatchTarget.ref, command);
+  const inputs = new PluginInput(context.eventHandler, stateId, context.key, context.payload, settings, token, dispatchTarget.sourceRef, command);
 
   context.logger.info({ plugin, worker: dispatchTarget.kind === "worker", command }, "Will dispatch command plugin.");
   try {

--- a/src/github/handlers/pull-request-review-comment-created.ts
+++ b/src/github/handlers/pull-request-review-comment-created.ts
@@ -183,7 +183,7 @@ async function dispatchReviewCommand(
   const stateId = crypto.randomUUID();
   const token = await context.eventHandler.getToken(context.payload.installation.id);
   const dispatchTarget = await resolvePluginDispatchTarget({ context, plugin, manifest: match.manifest });
-  const inputs = new PluginInput(context.eventHandler, stateId, context.key, context.payload, settings, token, dispatchTarget.ref, command);
+  const inputs = new PluginInput(context.eventHandler, stateId, context.key, context.payload, settings, token, dispatchTarget.sourceRef, command);
 
   context.logger.info({ plugin, worker: dispatchTarget.kind === "worker", command }, "Will dispatch command plugin from review thread.");
   try {

--- a/src/github/utils/plugin-dispatch.ts
+++ b/src/github/utils/plugin-dispatch.ts
@@ -3,12 +3,12 @@ import { GitHubContext } from "../github-context.ts";
 import { GithubPlugin } from "../types/plugin-configuration.ts";
 import { PluginInput } from "../types/plugin.ts";
 import { withKernelContextWorkflowInputsIfNeeded } from "./plugin-dispatch-settings.ts";
-import { getManifest, getWorkerUrlFromManifest } from "./plugins.ts";
+import { getManifest, getWorkerUrlFromManifest, toArtifactRef } from "./plugins.ts";
 import { dispatchWorker, dispatchWorkflow, dispatchWorkflowWithRunUrl, getDefaultBranch } from "./workflow-dispatch.ts";
 
 export type PluginDispatchTarget =
-  | { kind: "worker"; targetUrl: string; ref: string }
-  | { kind: "workflow"; owner: string; repository: string; workflowId: string; ref: string };
+  | { kind: "worker"; targetUrl: string; ref: string; sourceRef: string }
+  | { kind: "workflow"; owner: string; repository: string; workflowId: string; ref: string; sourceRef: string };
 
 type ResolveDispatchTargetOptions = {
   context: GitHubContext;
@@ -20,13 +20,14 @@ export async function resolvePluginDispatchTarget({ context, plugin, manifest }:
   const resolvedManifest = manifest ?? (await getManifest(context, plugin));
   const workerUrl = getWorkerUrlFromManifest(resolvedManifest);
   if (workerUrl) {
-    return { kind: "worker", targetUrl: workerUrl, ref: workerUrl };
+    return { kind: "worker", targetUrl: workerUrl, ref: workerUrl, sourceRef: workerUrl };
   }
   if (typeof plugin === "string") {
-    return { kind: "worker", targetUrl: plugin, ref: plugin };
+    return { kind: "worker", targetUrl: plugin, ref: plugin, sourceRef: plugin };
   }
-  const ref = plugin.ref ?? (await getDefaultBranch(context, plugin.owner, plugin.repo));
-  return { kind: "workflow", owner: plugin.owner, repository: plugin.repo, workflowId: plugin.workflowId, ref };
+  const sourceRef = plugin.ref ?? (await getDefaultBranch(context, plugin.owner, plugin.repo));
+  const ref = toArtifactRef(sourceRef);
+  return { kind: "workflow", owner: plugin.owner, repository: plugin.repo, workflowId: plugin.workflowId, ref, sourceRef };
 }
 
 type DispatchPluginTargetOptions = {

--- a/src/github/utils/plugins.ts
+++ b/src/github/utils/plugins.ts
@@ -7,6 +7,7 @@ import { GitHubContext } from "../github-context.ts";
 import { GithubPlugin, PluginConfiguration, PluginSettings, isGithubPlugin, parsePluginIdentifier } from "../types/plugin-configuration.ts";
 import { getEnvValue } from "./env.ts";
 import { isPlainObject } from "./helpers.ts";
+import { getDefaultBranch } from "./workflow-dispatch.ts";
 
 const MAX_MANIFEST_CACHE_SIZE = 100;
 const manifestCache = new Map<string, Manifest>();
@@ -54,6 +55,14 @@ function formatPluginTarget(target: string | GithubPlugin) {
   return typeof target === "string"
     ? target
     : `${target.owner}/${target.repo}${target.workflowId ? ":" + target.workflowId : ""}${target.ref ? "@" + target.ref : ""}`;
+}
+
+export function toArtifactRef(sourceRef: string) {
+  return sourceRef.startsWith("dist/") ? sourceRef : `dist/${sourceRef}`;
+}
+
+async function resolveSourceRef(context: GitHubContext, plugin: GithubPlugin) {
+  return plugin.ref ?? (await getDefaultBranch(context, plugin.owner, plugin.repo));
 }
 
 export function mergeWithDefaults<T>(defaults: T, overrides: unknown): T {
@@ -121,14 +130,19 @@ export function getManifest(context: GitHubContext, plugin: string | GithubPlugi
   return isGithubPlugin(plugin) ? fetchActionManifest(context, plugin) : fetchWorkerManifest(context, plugin);
 }
 
-async function fetchActionManifest(context: GitHubContext, { owner, repo, ref }: GithubPlugin): Promise<Manifest | null> {
-  const manifestKey = ref ? `${owner}:${repo}:${ref}` : `${owner}:${repo}`;
+async function fetchActionManifest(context: GitHubContext, plugin: GithubPlugin): Promise<Manifest | null> {
+  const { owner, repo } = plugin;
+  const sourceRef = await resolveSourceRef(context, plugin);
+  const artifactRef = toArtifactRef(sourceRef);
   const useCache = isManifestCacheEnabled(context);
-  if (useCache) {
-    const cached = readManifestCache(manifestKey);
-    if (cached) return cached;
-  }
-  try {
+
+  async function fetchByRef(ref: string): Promise<Manifest | null> {
+    const manifestKey = `${owner}:${repo}:${ref}`;
+    if (useCache) {
+      const cached = readManifestCache(manifestKey);
+      if (cached) return cached;
+    }
+
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000); // 5s timeout
     try {
@@ -139,21 +153,35 @@ async function fetchActionManifest(context: GitHubContext, { owner, repo, ref }:
         ref,
         request: { signal: controller.signal },
       });
-      if ("content" in data) {
-        const content = Buffer.from(data.content, "base64").toString();
-        const contentParsed = JSON.parse(content);
-        const manifest = decodeManifest(context, contentParsed);
-        if (useCache) {
-          setManifestCache(manifestKey, manifest);
-        }
-        return manifest;
+      if (!("content" in data)) {
+        return null;
       }
+      const content = Buffer.from(data.content, "base64").toString();
+      const contentParsed = JSON.parse(content);
+      const manifest = decodeManifest(context, contentParsed);
+      if (useCache) {
+        setManifestCache(manifestKey, manifest);
+      }
+      return manifest;
     } finally {
       clearTimeout(timeout);
     }
-  } catch (e) {
-    context.logger.error({ owner, repo, err: e }, "Could not find a manifest for Action");
   }
+
+  try {
+    return await fetchByRef(artifactRef);
+  } catch (error) {
+    context.logger.debug({ owner, repo, sourceRef, artifactRef, err: error }, "Artifact manifest lookup failed; trying source ref fallback");
+  }
+
+  if (artifactRef !== sourceRef) {
+    try {
+      return await fetchByRef(sourceRef);
+    } catch (error) {
+      context.logger.error({ owner, repo, sourceRef, artifactRef, err: error }, "Could not find a manifest for Action");
+    }
+  }
+
   return null;
 }
 

--- a/tests/configuration.test.ts
+++ b/tests/configuration.test.ts
@@ -96,81 +96,88 @@ Deno.test("Configuration: parses Action path when branch and workflow are specif
 });
 
 Deno.test({
-  name: "Configuration: retrieves the configuration manifest from the proper branch if specified",
+  name: "Configuration: resolves GitHub plugin manifests from dist/<source-ref> with source-ref fallback",
   sanitizeOps: false,
   sanitizeResources: false,
   fn: async () => {
-    let repo = "ubiquity-os-kernel";
-    let ref: string | undefined = "fork/pull/1";
     const owner = "ubiquity";
+    const repo = "ubiquity-os-kernel";
     const workflowId = "action.yml";
-    const content: Record<string, object> = {
-      withRef: {
-        name: "plugin",
-        short_name: "plugin",
-        homepage_url: "",
-        commands: {
-          command: {
-            description: "description",
-            "ubiquity:example": "example",
-          },
+
+    const artifactManifest = {
+      name: "plugin",
+      short_name: "plugin",
+      homepage_url: "",
+      commands: {
+        command: {
+          description: "description",
+          "ubiquity:example": "example",
         },
-        configuration: {},
-        description: "",
-        "ubiquity:listeners": [],
-        skipBotEvents: true,
       },
-      withoutRef: {
-        name: "plugin-no-ref",
-        short_name: "plugin-no-ref",
-        homepage_url: "",
-        commands: {
-          command: {
-            description: "description",
-            "ubiquity:example": "example",
-          },
-        },
-        configuration: {},
-        description: "",
-        "ubiquity:listeners": [],
-        skipBotEvents: true,
-      },
+      configuration: {},
+      description: "",
+      "ubiquity:listeners": [],
+      skipBotEvents: true,
     };
+
+    const legacyManifest = {
+      ...artifactManifest,
+      name: "plugin-legacy",
+      short_name: "plugin-legacy",
+    };
+
+    const calls: string[] = [];
     function getContent({ ref }: Record<string, string>) {
-      return {
-        data: {
-          content: btoa(JSON.stringify(ref ? content["withRef"] : content["withoutRef"])),
-        },
-      };
+      calls.push(ref);
+      if (ref === "dist/fork/pull/1") {
+        return { data: { content: btoa(JSON.stringify(artifactManifest)) } };
+      }
+      if (ref === "dist/main") {
+        const error = new Error("Not Found") as Error & { status?: number };
+        error.status = 404;
+        throw error;
+      }
+      if (ref === "main") {
+        return { data: { content: btoa(JSON.stringify(legacyManifest)) } };
+      }
+      throw new Error(`Unexpected ref: ${ref}`);
     }
-    let manifest = await getManifest(
-      {
-        octokit: {
-          rest: {
-            repos: {
-              getContent,
-            },
+
+    const context = {
+      octokit: {
+        rest: {
+          apps: {
+            getRepoInstallation: async () => ({ data: { id: 123 } }),
+          },
+          repos: {
+            getContent,
           },
         },
-      } as unknown as GitHubContext,
-      { owner, repo, ref, workflowId }
-    );
-    assertEquals(manifest, content["withRef"]);
-    ref = undefined;
-    repo = "repo-2";
-    manifest = await getManifest(
-      {
-        octokit: {
+      },
+      eventHandler: {
+        getAuthenticatedOctokit: () => ({
           rest: {
             repos: {
-              getContent,
+              get: async () => ({ data: { default_branch: "main" } }),
             },
           },
-        },
-      } as unknown as GitHubContext,
-      { owner, repo, ref, workflowId }
-    );
-    assertEquals(manifest, content["withoutRef"]);
+        }),
+        environment: "test",
+      },
+      logger: {
+        debug: () => {},
+        error: () => {},
+        warn: () => {},
+      },
+    } as unknown as GitHubContext;
+
+    const withRefManifest = await getManifest(context, { owner, repo, ref: "fork/pull/1", workflowId });
+    assertEquals(withRefManifest, artifactManifest);
+
+    const withoutRefManifest = await getManifest(context, { owner, repo, ref: undefined, workflowId });
+    assertEquals(withoutRefManifest, legacyManifest);
+
+    assertEquals(calls, ["dist/fork/pull/1", "dist/main", "main"]);
   },
 });
 

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -84,14 +84,14 @@ Deno.test("handleEvent: continues dispatching plugins if one throws", async () =
       ] as never;
     },
     getManifest: async () => ({ name: "plugin" }) as never,
-    resolvePluginDispatchTarget: async ({ plugin }) => ({ kind: "worker", targetUrl: String(plugin), ref: String(plugin) }) as never,
+    resolvePluginDispatchTarget: async ({ plugin }) => ({ kind: "worker", targetUrl: String(plugin), ref: String(plugin), sourceRef: String(plugin) }) as never,
     dispatchPluginTarget: async ({ plugin, pluginInput }) => {
       dispatches.push({ plugin: typeof plugin === "string" ? plugin : `${plugin.owner}/${plugin.repo}`, eventName: String(pluginInput.eventName) });
       dispatchAttempt += 1;
       if (dispatchAttempt === 1) {
         throw new Error("Test induced first call failure");
       }
-      return { target: { kind: "worker", targetUrl: "ok", ref: "ok" } } as never;
+      return { target: { kind: "worker", targetUrl: "ok", ref: "ok", sourceRef: "ok" } } as never;
     },
   };
 

--- a/tests/kernel.test.ts
+++ b/tests/kernel.test.ts
@@ -96,7 +96,7 @@ Deno.test("Kernel: dispatches configured worker plugins via onAny pipeline", asy
         settings: { runsOn: [ISSUE_COMMENT_CREATED], skipBotEvents: false, with: {} },
       } as never,
     ],
-    resolvePluginDispatchTarget: async () => ({ kind: "worker", targetUrl: TEST_WORKER_URL, ref: TEST_WORKER_URL }) as never,
+    resolvePluginDispatchTarget: async () => ({ kind: "worker", targetUrl: TEST_WORKER_URL, ref: TEST_WORKER_URL, sourceRef: TEST_WORKER_URL }) as never,
     dispatchPluginTarget: async ({ target }) => {
       dispatched.push({ targetUrl: (target as { targetUrl: string }).targetUrl });
       return { target, response: new Response(null, { status: 200 }) };

--- a/tests/plugin-dispatch.test.ts
+++ b/tests/plugin-dispatch.test.ts
@@ -39,7 +39,7 @@ Deno.test("resolvePluginDispatchTarget: prefers manifest worker urls for github 
 
   const target = await resolvePluginDispatchTarget({ context, plugin, manifest });
 
-  assertEquals(target, { kind: "worker", targetUrl: URL_EXAMPLE, ref: URL_EXAMPLE });
+  assertEquals(target, { kind: "worker", targetUrl: URL_EXAMPLE, ref: URL_EXAMPLE, sourceRef: URL_EXAMPLE });
   assertEquals(reposGetCalls, 0);
 });
 
@@ -80,5 +80,12 @@ Deno.test("resolvePluginDispatchTarget: falls back to workflow dispatch using th
 
   assertEquals(appsGetRepoInstallationCalls, 1);
   assertEquals(reposGetCalls, 1);
-  assertEquals(target, { kind: "workflow", owner: "octo", repository: "demo", workflowId: WORKFLOW_ID, ref: "main" });
+  assertEquals(target, {
+    kind: "workflow",
+    owner: "octo",
+    repository: "demo",
+    workflowId: WORKFLOW_ID,
+    ref: "dist/main",
+    sourceRef: "main",
+  });
 });

--- a/tests/plugin-error.test.ts
+++ b/tests/plugin-error.test.ts
@@ -106,7 +106,7 @@ Deno.test("kernel.plugin_error: dispatches to subscribed plugins when plugin dis
       }
       return null;
     },
-    resolvePluginDispatchTarget: async ({ plugin }) => ({ kind: "worker", targetUrl: String(plugin), ref: String(plugin) }) as never,
+    resolvePluginDispatchTarget: async ({ plugin }) => ({ kind: "worker", targetUrl: String(plugin), ref: String(plugin), sourceRef: String(plugin) }) as never,
     dispatchPluginTarget: async ({ plugin, pluginInput }) => {
       const pluginId = typeof plugin === "string" ? plugin : `${plugin.owner}/${plugin.repo}`;
       captured.push({ plugin: pluginId, eventName: String(pluginInput.eventName), eventPayload: pluginInput.eventPayload });
@@ -114,7 +114,7 @@ Deno.test("kernel.plugin_error: dispatches to subscribed plugins when plugin dis
       if (dispatchAttempt === 1) {
         throw new Error("HTTP 502: bad gateway");
       }
-      return { target: { kind: "worker", targetUrl: pluginId, ref: pluginId } } as never;
+      return { target: { kind: "worker", targetUrl: pluginId, ref: pluginId, sourceRef: pluginId } } as never;
     },
   };
 
@@ -184,11 +184,11 @@ Deno.test({
         }
         return null;
       },
-      resolvePluginDispatchTarget: async ({ plugin }) => ({ kind: "worker", targetUrl: String(plugin), ref: String(plugin) }) as never,
+      resolvePluginDispatchTarget: async ({ plugin }) => ({ kind: "worker", targetUrl: String(plugin), ref: String(plugin), sourceRef: String(plugin) }) as never,
       dispatchPluginTarget: async ({ plugin, pluginInput }) => {
         const pluginId = typeof plugin === "string" ? plugin : `${plugin.owner}/${plugin.repo}`;
         captured.push({ plugin: pluginId, eventName: String(pluginInput.eventName), eventPayload: pluginInput.eventPayload });
-        return { target: { kind: "worker", targetUrl: pluginId, ref: pluginId } } as never;
+        return { target: { kind: "worker", targetUrl: pluginId, ref: pluginId, sourceRef: pluginId } } as never;
       },
     };
 


### PR DESCRIPTION
## Summary
Implements the kernel portion of #320 for GitHub plugins:
- manifest resolution now prefers `dist/<source-ref>`
- workflow dispatch now targets `dist/<source-ref>`
- migration-safe fallback to legacy source ref is preserved for manifest lookup
- `PluginInput.ref` semantics remain unchanged (it still carries source ref)

## What changed
- Added `toArtifactRef(sourceRef)` mapping helper (`dist/<source-ref>`, idempotent for `dist/*`).
- Updated GitHub manifest fetch logic to:
  1) resolve source ref (`plugin.ref` or default branch),
  2) try `manifest.json` on artifact ref first,
  3) fallback to source ref if artifact manifest is missing/unavailable.
- Updated plugin dispatch target resolution for GitHub workflow plugins to dispatch on artifact refs while carrying `sourceRef` separately.
- Updated event handlers to construct `PluginInput` with `dispatchTarget.sourceRef` (preserving existing input behavior).
- Added/updated tests to cover mapping + fallback + ref semantics in dispatch stubs.

## Acceptance checklist mapping (kernel scope)
- [x] For source ref `R`, kernel resolves manifests/dispatch from artifact ref `dist/R`.
- [x] `PluginInput.ref` behavior remains unchanged (source ref passed to `PluginInput`).
- [x] Migration fallback exists: if artifact manifest lookup fails, kernel retries legacy source ref.
- [x] No recursive `dist/dist/*` mapping (`toArtifactRef` is idempotent for `dist/*`).
- [x] Unit tests added/updated for mapping + fallback behavior.

## Tests
- Updated: `tests/configuration.test.ts` (artifact lookup + fallback)
- Updated: `tests/plugin-dispatch.test.ts` (dispatch ref -> `dist/<source-ref>` + sourceRef separation)
- Updated stubs impacted by `PluginDispatchTarget` shape: `dispatch.test.ts`, `kernel.test.ts`, `plugin-error.test.ts`

Note: Test execution is currently blocked in this environment because `deno` is not installed (`deno: command not found`).
