### PR TITLE
[codex] Fix bot-to-bot comment routing loops for help and agent paths

### DIFF
--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -57,6 +57,5 @@ jobs:
         with:
           token: ${{ secrets.DENO_DEPLOY_TOKEN }}
           action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
-          organization: ${{ secrets.DENO_ORG_NAME }}
           entrypoint: src/kernel.ts
           buildManifest: false

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -59,4 +59,4 @@ jobs:
           action: ${{ github.event_name == 'delete' && 'delete' || 'deploy' }}
           organization: ${{ secrets.DENO_ORG_NAME }}
           entrypoint: src/kernel.ts
-          project_name: ${{ secrets.DENO_PROJECT_NAME }}
+          buildManifest: false

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -54,6 +54,7 @@ jobs:
           # SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID || '' }}
           NODE_ENV: "production"
           GIT_REVISION: ${{ github.sha }}
+          LOG_LEVEL: ${{ vars.LOG_LEVEL || 'info' }}
         with:
           token: ${{ secrets.DENO_DEPLOY_TOKEN }}
           action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -56,7 +56,7 @@ jobs:
           GIT_REVISION: ${{ github.sha }}
         with:
           token: ${{ secrets.DENO_DEPLOY_TOKEN }}
-          action: ${{ github.event_name == 'delete' && 'delete' || 'deploy' }}
+          action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
           organization: ${{ secrets.DENO_ORG_NAME }}
           entrypoint: src/kernel.ts
           buildManifest: false

--- a/deno.lock
+++ b/deno.lock
@@ -35,8 +35,8 @@
     "npm:jest-mock@29.7.0": "29.7.0",
     "npm:js-yaml@4.1.0": "4.1.0",
     "npm:lint-staged@15.2.7": "15.2.7",
-    "npm:pino-pretty@13.1.1": "13.1.1",
-    "npm:pino@9.0.0": "9.0.0",
+    "npm:pino-pretty@13.1.3": "13.1.3",
+    "npm:pino@10.3.1": "10.3.1",
     "npm:prettier@3.3.3": "3.3.3",
     "npm:typescript-eslint@8.49.0": "8.49.0_eslint@9.7.0_typescript@5.9.3_@typescript-eslint+parser@8.49.0__eslint@9.7.0__typescript@5.9.3",
     "npm:yaml@2.7.0": "2.7.0"
@@ -929,6 +929,9 @@
         "@octokit/webhooks-methods"
       ]
     },
+    "@pinojs/redact@0.4.0": {
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
+    },
     "@sinclair/typebox@0.27.8": {
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
@@ -1104,12 +1107,6 @@
       ],
       "bin": true
     },
-    "abort-controller@3.0.0": {
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": [
-        "event-target-shim"
-      ]
-    },
     "acorn-jsx@5.3.2_acorn@8.15.0": {
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dependencies": [
@@ -1177,9 +1174,6 @@
     "balanced-match@1.0.2": {
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "base64-js@1.5.1": {
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "before-after-hook@2.2.3": {
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
@@ -1206,13 +1200,6 @@
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": [
         "fill-range"
-      ]
-    },
-    "buffer@6.0.3": {
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dependencies": [
-        "base64-js",
-        "ieee754"
       ]
     },
     "callsites@3.1.0": {
@@ -1620,9 +1607,6 @@
     "esutils@2.0.3": {
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
-    "event-target-shim@5.0.1": {
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
     "eventemitter3@5.0.1": {
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
@@ -1656,8 +1640,8 @@
     "fast-content-type-parse@3.0.0": {
       "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="
     },
-    "fast-copy@3.0.2": {
-      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="
+    "fast-copy@4.0.2": {
+      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="
     },
     "fast-deep-equal@3.1.3": {
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
@@ -1680,9 +1664,6 @@
     },
     "fast-levenshtein@2.0.6": {
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-    },
-    "fast-redact@3.5.0": {
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="
     },
     "fast-safe-stringify@2.1.1": {
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
@@ -1818,9 +1799,6 @@
     },
     "human-signals@5.0.0": {
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="
-    },
-    "ieee754@1.2.1": {
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore@5.3.2": {
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
@@ -2235,21 +2213,14 @@
       "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
       "bin": true
     },
-    "pino-abstract-transport@1.2.0": {
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "dependencies": [
-        "readable-stream",
-        "split2"
-      ]
-    },
-    "pino-abstract-transport@2.0.0": {
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+    "pino-abstract-transport@3.0.0": {
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
       "dependencies": [
         "split2"
       ]
     },
-    "pino-pretty@13.1.1": {
-      "integrity": "sha512-TNNEOg0eA0u+/WuqH0MH0Xui7uqVk9D74ESOpjtebSQYbNWJk/dIxCXIxFsNfeN53JmtWqYHP2OrIZjT/CBEnA==",
+    "pino-pretty@13.1.3": {
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
       "dependencies": [
         "colorette",
         "dateformat",
@@ -2259,30 +2230,30 @@
         "joycon",
         "minimist",
         "on-exit-leak-free",
-        "pino-abstract-transport@2.0.0",
+        "pino-abstract-transport",
         "pump",
         "secure-json-parse",
-        "sonic-boom@4.2.0",
+        "sonic-boom",
         "strip-json-comments@5.0.3"
       ],
       "bin": true
     },
-    "pino-std-serializers@6.2.2": {
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+    "pino-std-serializers@7.1.0": {
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="
     },
-    "pino@9.0.0": {
-      "integrity": "sha512-uI1ThkzTShNSwvsUM6b4ND8ANzWURk9zTELMztFkmnCQeR/4wkomJ+echHee5GMWGovoSfjwdeu80DsFIt7mbA==",
+    "pino@10.3.1": {
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "dependencies": [
+        "@pinojs/redact",
         "atomic-sleep",
-        "fast-redact",
         "on-exit-leak-free",
-        "pino-abstract-transport@1.2.0",
+        "pino-abstract-transport",
         "pino-std-serializers",
         "process-warning",
         "quick-format-unescaped",
         "real-require",
         "safe-stable-stringify",
-        "sonic-boom@3.8.1",
+        "sonic-boom",
         "thread-stream"
       ],
       "bin": true
@@ -2302,14 +2273,11 @@
         "react-is"
       ]
     },
-    "process-warning@3.0.0": {
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+    "process-warning@5.0.0": {
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="
     },
-    "process@0.11.10": {
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
-    },
-    "pump@3.0.3": {
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+    "pump@3.0.4": {
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dependencies": [
         "end-of-stream",
         "once"
@@ -2326,16 +2294,6 @@
     },
     "react-is@18.3.1": {
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-    },
-    "readable-stream@4.7.0": {
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dependencies": [
-        "abort-controller",
-        "buffer",
-        "events",
-        "process",
-        "string_decoder"
-      ]
     },
     "real-require@0.2.0": {
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
@@ -2370,9 +2328,6 @@
       "dependencies": [
         "queue-microtask"
       ]
-    },
-    "safe-buffer@5.2.1": {
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-stable-stringify@2.5.0": {
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="
@@ -2413,14 +2368,8 @@
         "is-fullwidth-code-point@5.1.0"
       ]
     },
-    "sonic-boom@3.8.1": {
-      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
-      "dependencies": [
-        "atomic-sleep"
-      ]
-    },
-    "sonic-boom@4.2.0": {
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+    "sonic-boom@4.2.1": {
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "dependencies": [
         "atomic-sleep"
       ]
@@ -2451,12 +2400,6 @@
         "emoji-regex@10.6.0",
         "get-east-asian-width",
         "strip-ansi@7.1.2"
-      ]
-    },
-    "string_decoder@1.3.0": {
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": [
-        "safe-buffer"
       ]
     },
     "strip-ansi@6.0.1": {
@@ -2492,8 +2435,8 @@
     "text-table@0.2.0": {
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
-    "thread-stream@2.7.0": {
-      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+    "thread-stream@4.0.0": {
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
       "dependencies": [
         "real-require"
       ]
@@ -2718,8 +2661,8 @@
       "npm:hono@4.9.1",
       "npm:js-yaml@4.1.0",
       "npm:lint-staged@15.2.7",
-      "npm:pino-pretty@13.1.1",
-      "npm:pino@9.0.0",
+      "npm:pino-pretty@13.1.3",
+      "npm:pino@10.3.1",
       "npm:prettier@3.3.3",
       "npm:typescript-eslint@8.49.0",
       "npm:yaml@2.7.0"

--- a/deno.lock
+++ b/deno.lock
@@ -35,8 +35,8 @@
     "npm:jest-mock@29.7.0": "29.7.0",
     "npm:js-yaml@4.1.0": "4.1.0",
     "npm:lint-staged@15.2.7": "15.2.7",
-    "npm:pino-pretty@13.1.3": "13.1.3",
-    "npm:pino@10.3.1": "10.3.1",
+    "npm:pino-pretty@13.1.1": "13.1.1",
+    "npm:pino@9.0.0": "9.0.0",
     "npm:prettier@3.3.3": "3.3.3",
     "npm:typescript-eslint@8.49.0": "8.49.0_eslint@9.7.0_typescript@5.9.3_@typescript-eslint+parser@8.49.0__eslint@9.7.0__typescript@5.9.3",
     "npm:yaml@2.7.0": "2.7.0"
@@ -929,9 +929,6 @@
         "@octokit/webhooks-methods"
       ]
     },
-    "@pinojs/redact@0.4.0": {
-      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
-    },
     "@sinclair/typebox@0.27.8": {
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
@@ -1107,6 +1104,12 @@
       ],
       "bin": true
     },
+    "abort-controller@3.0.0": {
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": [
+        "event-target-shim"
+      ]
+    },
     "acorn-jsx@5.3.2_acorn@8.15.0": {
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dependencies": [
@@ -1174,6 +1177,9 @@
     "balanced-match@1.0.2": {
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-js@1.5.1": {
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "before-after-hook@2.2.3": {
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
@@ -1200,6 +1206,13 @@
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": [
         "fill-range"
+      ]
+    },
+    "buffer@6.0.3": {
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dependencies": [
+        "base64-js",
+        "ieee754"
       ]
     },
     "callsites@3.1.0": {
@@ -1607,6 +1620,9 @@
     "esutils@2.0.3": {
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "event-target-shim@5.0.1": {
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "eventemitter3@5.0.1": {
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
@@ -1640,8 +1656,8 @@
     "fast-content-type-parse@3.0.0": {
       "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="
     },
-    "fast-copy@4.0.2": {
-      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="
+    "fast-copy@3.0.2": {
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="
     },
     "fast-deep-equal@3.1.3": {
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
@@ -1664,6 +1680,9 @@
     },
     "fast-levenshtein@2.0.6": {
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "fast-redact@3.5.0": {
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="
     },
     "fast-safe-stringify@2.1.1": {
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
@@ -1799,6 +1818,9 @@
     },
     "human-signals@5.0.0": {
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="
+    },
+    "ieee754@1.2.1": {
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore@5.3.2": {
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
@@ -2213,14 +2235,21 @@
       "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
       "bin": true
     },
-    "pino-abstract-transport@3.0.0": {
-      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+    "pino-abstract-transport@1.2.0": {
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "dependencies": [
+        "readable-stream",
+        "split2"
+      ]
+    },
+    "pino-abstract-transport@2.0.0": {
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
       "dependencies": [
         "split2"
       ]
     },
-    "pino-pretty@13.1.3": {
-      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+    "pino-pretty@13.1.1": {
+      "integrity": "sha512-TNNEOg0eA0u+/WuqH0MH0Xui7uqVk9D74ESOpjtebSQYbNWJk/dIxCXIxFsNfeN53JmtWqYHP2OrIZjT/CBEnA==",
       "dependencies": [
         "colorette",
         "dateformat",
@@ -2230,30 +2259,30 @@
         "joycon",
         "minimist",
         "on-exit-leak-free",
-        "pino-abstract-transport",
+        "pino-abstract-transport@2.0.0",
         "pump",
         "secure-json-parse",
-        "sonic-boom",
+        "sonic-boom@4.2.1",
         "strip-json-comments@5.0.3"
       ],
       "bin": true
     },
-    "pino-std-serializers@7.1.0": {
-      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="
+    "pino-std-serializers@6.2.2": {
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
     },
-    "pino@10.3.1": {
-      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+    "pino@9.0.0": {
+      "integrity": "sha512-uI1ThkzTShNSwvsUM6b4ND8ANzWURk9zTELMztFkmnCQeR/4wkomJ+echHee5GMWGovoSfjwdeu80DsFIt7mbA==",
       "dependencies": [
-        "@pinojs/redact",
         "atomic-sleep",
+        "fast-redact",
         "on-exit-leak-free",
-        "pino-abstract-transport",
+        "pino-abstract-transport@1.2.0",
         "pino-std-serializers",
         "process-warning",
         "quick-format-unescaped",
         "real-require",
         "safe-stable-stringify",
-        "sonic-boom",
+        "sonic-boom@3.8.1",
         "thread-stream"
       ],
       "bin": true
@@ -2273,8 +2302,11 @@
         "react-is"
       ]
     },
-    "process-warning@5.0.0": {
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="
+    "process-warning@3.0.0": {
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+    },
+    "process@0.11.10": {
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "pump@3.0.4": {
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
@@ -2294,6 +2326,16 @@
     },
     "react-is@18.3.1": {
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "readable-stream@4.7.0": {
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dependencies": [
+        "abort-controller",
+        "buffer",
+        "events",
+        "process",
+        "string_decoder"
+      ]
     },
     "real-require@0.2.0": {
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
@@ -2328,6 +2370,9 @@
       "dependencies": [
         "queue-microtask"
       ]
+    },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-stable-stringify@2.5.0": {
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="
@@ -2368,6 +2413,12 @@
         "is-fullwidth-code-point@5.1.0"
       ]
     },
+    "sonic-boom@3.8.1": {
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "dependencies": [
+        "atomic-sleep"
+      ]
+    },
     "sonic-boom@4.2.1": {
       "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "dependencies": [
@@ -2400,6 +2451,12 @@
         "emoji-regex@10.6.0",
         "get-east-asian-width",
         "strip-ansi@7.1.2"
+      ]
+    },
+    "string_decoder@1.3.0": {
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": [
+        "safe-buffer"
       ]
     },
     "strip-ansi@6.0.1": {
@@ -2435,8 +2492,8 @@
     "text-table@0.2.0": {
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
-    "thread-stream@4.0.0": {
-      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+    "thread-stream@2.7.0": {
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
       "dependencies": [
         "real-require"
       ]
@@ -2661,8 +2718,8 @@
       "npm:hono@4.9.1",
       "npm:js-yaml@4.1.0",
       "npm:lint-staged@15.2.7",
-      "npm:pino-pretty@13.1.3",
-      "npm:pino@10.3.1",
+      "npm:pino-pretty@13.1.1",
+      "npm:pino@9.0.0",
       "npm:prettier@3.3.3",
       "npm:typescript-eslint@8.49.0",
       "npm:yaml@2.7.0"

--- a/src/github/handlers/help-command.ts
+++ b/src/github/handlers/help-command.ts
@@ -1,5 +1,6 @@
 import { GitHubContext } from "../github-context.ts";
 import { GithubPlugin, parsePluginIdentifier } from "../types/plugin-configuration.ts";
+import { COMMAND_RESPONSE_MARKER, hasCommandResponseMarker } from "../utils/comment-routing.ts";
 import { getConfig } from "../utils/config.ts";
 import { getManifest } from "../utils/plugins.ts";
 import { getKernelCommit } from "../utils/kernel-metadata.ts";
@@ -9,7 +10,6 @@ type CommandRow = {
   row: string;
 };
 
-const COMMAND_RESPONSE_MARKER = '"commentKind": "command-response"';
 const COMMAND_RESPONSE_COMMENT_LIMIT = 50;
 const RECENT_COMMENTS_QUERY = `
   query($owner: String!, $repo: String!, $number: Int!, $last: Int!) {
@@ -94,7 +94,12 @@ export async function postHelpCommand(context: GitHubContext<"issue_comment.crea
   const comments = ["| Command | Description | Example |", "|---|---|---|"];
   const commandRows = new Map<string, string>();
   const configuration = await getConfig(context);
-  context.logger.info({ pluginCount: Object.keys(configuration?.plugins || {}).length }, "Processing help command");
+  context.logger.info(
+    {
+      pluginCount: Object.keys(configuration?.plugins || {}).length,
+    },
+    "Processing help command"
+  );
 
   commandRows.set("help", "| `/help` | List all available commands. | `/help` |");
 
@@ -108,7 +113,13 @@ export async function postHelpCommand(context: GitHubContext<"issue_comment.crea
     }
 
     const manifestCommands = await parseCommandsFromManifest(context, plugin);
-    context.logger.debug({ plugin: pluginKey, commandsCount: manifestCommands.length }, "Parsed commands for plugin");
+    context.logger.debug(
+      {
+        plugin: pluginKey,
+        commandsCount: manifestCommands.length,
+      },
+      "Parsed commands for plugin"
+    );
 
     for (const command of manifestCommands) {
       commandRows.set(command.key, command.row);
@@ -125,7 +136,9 @@ export async function postHelpCommand(context: GitHubContext<"issue_comment.crea
         return a.localeCompare(b);
       })
       .map(([, row]) => row);
-    const footer = `\n\n###### UbiquityOS ${environment.charAt(0).toUpperCase() + environment.slice(1).toLowerCase()} [${commitHash}](https://github.com/ubiquity-os/ubiquity-os-kernel/commit/${commitHash})`;
+    const footer = `\n\n###### UbiquityOS ${
+      environment.charAt(0).toUpperCase() + environment.slice(1).toLowerCase()
+    } [${commitHash}](https://github.com/ubiquity-os/ubiquity-os-kernel/commit/${commitHash})`;
     const body = appendCommandResponseMarker(comments.concat(commands).join("\n") + footer);
     await context.octokit.rest.issues.createComment({
       body,
@@ -139,10 +152,6 @@ export async function postHelpCommand(context: GitHubContext<"issue_comment.crea
 function appendCommandResponseMarker(body: string): string {
   if (body.includes(COMMAND_RESPONSE_MARKER)) return body;
   return `${body}\n\n<!-- ${COMMAND_RESPONSE_MARKER} -->`;
-}
-
-function hasCommandResponseMarker(body: string | null | undefined): boolean {
-  return typeof body === "string" && body.includes(COMMAND_RESPONSE_MARKER);
 }
 
 function getIssueLocator(context: GitHubContext<"issue_comment.created">): { owner: string; repo: string; issueNumber: number } | null {
@@ -174,7 +183,10 @@ async function getCommentNodeId(context: GitHubContext<"issue_comment.created">)
     const fetchedNodeId = (data as { node_id?: string | null }).node_id;
     return typeof fetchedNodeId === "string" && fetchedNodeId.trim() ? fetchedNodeId : null;
   } catch (error) {
-    context.logger.debug("Failed to fetch comment node id (non-fatal)", { err: error, commentId });
+    context.logger.debug("Failed to fetch comment node id (non-fatal)", {
+      err: error,
+      commentId,
+    });
     return null;
   }
 }
@@ -214,7 +226,9 @@ async function fetchRecentComments(
     const nodes = data.repository?.issueOrPullRequest?.comments?.nodes ?? [];
     return nodes.filter((node): node is GraphqlCommentNode => Boolean(node));
   } catch (error) {
-    context.logger.debug("Failed to fetch recent comments (non-fatal)", { err: error });
+    context.logger.debug("Failed to fetch recent comments (non-fatal)", {
+      err: error,
+    });
     return [];
   }
 }
@@ -244,7 +258,10 @@ async function minimizeComment(
       classifier,
     });
   } catch (error) {
-    context.logger.debug("Failed to minimize comment (non-fatal)", { err: error, commentNodeId });
+    context.logger.debug("Failed to minimize comment (non-fatal)", {
+      err: error,
+      commentNodeId,
+    });
   }
 }
 

--- a/src/github/handlers/index.ts
+++ b/src/github/handlers/index.ts
@@ -5,10 +5,11 @@ import { GitHubContext } from "../github-context.ts";
 import { GitHubEventHandler } from "../github-event-handler.ts";
 import { isGithubPlugin, type PluginConfiguration } from "../types/plugin-configuration.ts";
 import { PluginInput } from "../types/plugin.ts";
-import { getConfig, getConfigFullPathForEnvironment, type ConfigSource } from "../utils/config.ts";
+import { type ConfigSource, getConfig, getConfigFullPathForEnvironment } from "../utils/config.ts";
 import { getKernelCommit } from "../utils/kernel-metadata.ts";
 import { dispatchPluginTarget, resolvePluginDispatchTarget } from "../utils/plugin-dispatch.ts";
-import { ResolvedPlugin, getManifest, getPluginsForEvent } from "../utils/plugins.ts";
+import { getManifest, getPluginsForEvent, ResolvedPlugin } from "../utils/plugins.ts";
+import { getCreatedCommentRouteContext, shouldSkipBotInvocationDispatch } from "../utils/comment-routing.ts";
 import { handleAgentRunCommentEdited } from "./agent-run-comment.ts";
 import issueCommentCreated from "./issue-comment-created.ts";
 import pullRequestReviewCommentCreated from "./pull-request-review-comment-created.ts";
@@ -138,7 +139,9 @@ function extractRepositoryFullName(payload: unknown): string {
 
   const owner = (payload.repository as { owner?: { login?: unknown } }).owner?.login;
   const name = (payload.repository as { name?: unknown }).name;
-  if (typeof owner === "string" && typeof name === "string" && owner && name) return `${owner}/${name}`;
+  if (typeof owner === "string" && typeof name === "string" && owner && name) {
+    return `${owner}/${name}`;
+  }
   return "";
 }
 
@@ -404,8 +407,12 @@ async function emitKernelPluginErrorEvent({
   const safePluginWith: Record<string, unknown> = {};
   const failingWith = failingPluginEntry.settings?.with;
   if (failingWith && typeof failingWith === "object") {
-    if ("sourceRepo" in failingWith) safePluginWith.sourceRepo = (failingWith as { sourceRepo?: unknown }).sourceRepo;
-    if ("sourceRef" in failingWith) safePluginWith.sourceRef = (failingWith as { sourceRef?: unknown }).sourceRef;
+    if ("sourceRepo" in failingWith) {
+      safePluginWith.sourceRepo = (failingWith as { sourceRepo?: unknown }).sourceRepo;
+    }
+    if ("sourceRef" in failingWith) {
+      safePluginWith.sourceRef = (failingWith as { sourceRef?: unknown }).sourceRef;
+    }
   }
 
   const targetInstallationId = targetRepo ? await tryGetRepoInstallationId(context.eventHandler, targetRepo.owner, targetRepo.repo) : null;
@@ -440,7 +447,10 @@ async function emitKernelPluginErrorEvent({
     const settings = pluginEntry.settings;
     const stateId = crypto.randomUUID();
     try {
-      const dispatchTarget = await deps.resolvePluginDispatchTarget({ context, plugin });
+      const dispatchTarget = await deps.resolvePluginDispatchTarget({
+        context,
+        plugin,
+      });
       const eventPayload = payload as unknown as EmitterWebhookEvent<EmitterWebhookEventName>["payload"];
       const inputs = new PluginInput(
         context.eventHandler,
@@ -533,7 +543,10 @@ async function emitKernelErrorEvent({
     const settings = pluginEntry.settings;
     const stateId = crypto.randomUUID();
     try {
-      const dispatchTarget = await deps.resolvePluginDispatchTarget({ context, plugin });
+      const dispatchTarget = await deps.resolvePluginDispatchTarget({
+        context,
+        plugin,
+      });
       const eventPayload = payload as unknown as EmitterWebhookEvent<EmitterWebhookEventName>["payload"];
       const inputs = new PluginInput(
         context.eventHandler,
@@ -600,20 +613,8 @@ export function bindHandlers(eventHandler: GitHubEventHandler, deps?: Partial<Ha
   eventHandler.onAny(tryCatchWrapper((event) => handleEvent(event, eventHandler, resolvedDeps), eventHandler.logger, eventHandler, resolvedDeps)); // onAny should also receive GithubContext but the types in octokit/webhooks are weird
 }
 
-function extractLeadingSlashCommandName(body: string): string | null {
-  const trimmed = body.trimStart();
-  const match = /^\/([\w-]+)/u.exec(trimmed);
-  return match?.[1] ? match[1].toLowerCase() : null;
-}
-
-function extractSlashCommandNameFromCommentBody(body: string): string | null {
-  const direct = extractLeadingSlashCommandName(body);
-  if (direct) return direct;
-
-  const mention = /@ubiquityos\b/i.exec(body);
-  if (!mention || mention.index === undefined) return null;
-  const afterMention = body.slice(mention.index + mention[0].length);
-  return extractLeadingSlashCommandName(afterMention);
+function getCreatedCommentRoutingContext(context: GitHubContext<"issue_comment.created" | "pull_request_review_comment.created">) {
+  return getCreatedCommentRouteContext(context.payload.comment?.body, context.payload.comment?.user?.type);
 }
 
 async function filterPluginsForSlashCommandEvent(
@@ -685,7 +686,15 @@ async function handleEvent(event: EmitterWebhookEvent, eventHandler: InstanceTyp
 
   if (context.key === "issue_comment.created") {
     const issueContext = context as GitHubContext<"issue_comment.created">;
-    const commandName = extractSlashCommandNameFromCommentBody(String(issueContext.payload.comment?.body ?? ""));
+    const routingContext = getCreatedCommentRoutingContext(issueContext);
+    if (shouldSkipBotInvocationDispatch(issueContext.payload.comment?.body, issueContext.payload.comment?.user?.type)) {
+      context.logger.debug(
+        { author: issueContext.payload.comment?.user?.login },
+        "Skipping global dispatch for bot-authored invocation or command-response comment"
+      );
+      return;
+    }
+    const commandName = routingContext.slashInvocation?.name.toLowerCase() ?? null;
     if (commandName) {
       const filtered = await filterPluginsForSlashCommandEvent(context, resolvedPlugins, commandName, deps);
       resolvedPlugins.length = 0;
@@ -695,7 +704,15 @@ async function handleEvent(event: EmitterWebhookEvent, eventHandler: InstanceTyp
 
   if (context.key === "pull_request_review_comment.created") {
     const reviewContext = context as GitHubContext<"pull_request_review_comment.created">;
-    const commandName = extractSlashCommandNameFromCommentBody(String(reviewContext.payload.comment?.body ?? ""));
+    const routingContext = getCreatedCommentRoutingContext(reviewContext);
+    if (shouldSkipBotInvocationDispatch(reviewContext.payload.comment?.body, reviewContext.payload.comment?.user?.type)) {
+      context.logger.debug(
+        { author: reviewContext.payload.comment?.user?.login },
+        "Skipping global dispatch for bot-authored invocation or command-response review comment"
+      );
+      return;
+    }
+    const commandName = routingContext.slashInvocation?.name.toLowerCase() ?? null;
     if (commandName) {
       const filtered = await filterPluginsForSlashCommandEvent(context, resolvedPlugins, commandName, deps);
       resolvedPlugins.length = 0;
@@ -721,11 +738,20 @@ async function handleEvent(event: EmitterWebhookEvent, eventHandler: InstanceTyp
 
     // We wrap the dispatch so a failing plugin doesn't break the whole execution
     try {
-      const dispatchTarget = await deps.resolvePluginDispatchTarget({ context, plugin });
+      const dispatchTarget = await deps.resolvePluginDispatchTarget({
+        context,
+        plugin,
+      });
       ref = dispatchTarget.ref;
       const inputs = new PluginInput(context.eventHandler, stateId, context.key, event.payload, settings?.with, token, ref, null);
 
-      context.logger.debug({ plugin: pluginEntry.key, worker: dispatchTarget.kind === "worker" }, DISPATCH_EVENT_LOG);
+      context.logger.debug(
+        {
+          plugin: pluginEntry.key,
+          worker: dispatchTarget.kind === "worker",
+        },
+        DISPATCH_EVENT_LOG
+      );
       const result = await deps.dispatchPluginTarget({
         context,
         plugin,

--- a/src/github/handlers/issue-comment-created.ts
+++ b/src/github/handlers/issue-comment-created.ts
@@ -3,6 +3,7 @@ import { GitHubContext } from "../github-context.ts";
 import { PluginInput } from "../types/plugin.ts";
 import { GithubPlugin, parsePluginIdentifier } from "../types/plugin-configuration.ts";
 import { getAgentMemorySnippet, listAgentMemoryEntries, upsertAgentRunMemory } from "../utils/agent-memory.ts";
+import { extractAfterUbiquityosMention, getCreatedCommentRouteContext, type SlashCommandInvocation } from "../utils/comment-routing.ts";
 import { shouldSkipDuplicateCommentEvent } from "../utils/comment-dedupe.ts";
 import { getConfig } from "../utils/config.ts";
 import { getManifestResolution } from "../utils/plugins.ts";
@@ -16,11 +17,6 @@ import { updateRequestCommentRunUrl } from "../utils/request-comment-run-url.ts"
 import { resolveConversationKeyForContext } from "../utils/conversation-graph.ts";
 import { buildConversationContext } from "../utils/conversation-context.ts";
 import { getRouterDecision } from "./router-decision.ts";
-
-type SlashCommandInvocation = {
-  name: string;
-  rawArgs: string;
-};
 
 async function addReactionEyes(context: GitHubContext<"issue_comment.created">) {
   const commentId = context.payload.comment.id;
@@ -114,11 +110,9 @@ async function isUserHelpRequest(context: GitHubContext<"issue_comment.created">
 }
 
 export default async function issueCommentCreated(context: GitHubContext<"issue_comment.created">) {
-  const body = context.payload.comment.body.trim();
-  const bodyLower = body.toLowerCase();
-  const afterMention = extractAfterUbiquityosMention(body);
-  const slashInvocation = afterMention ? extractSlashCommandInvocation(afterMention) : extractSlashCommandInvocation(body);
-  const isHuman = context.payload.comment.user?.type === "User";
+  const routeContext = getCreatedCommentRouteContext(context.payload.comment.body, context.payload.comment.user?.type);
+  const body = routeContext.trimmedBody;
+  const { afterMention, slashInvocation, isHumanAuthor: isHuman } = routeContext;
   const shouldSkip = await shouldSkipDuplicateCommentEvent({
     owner: context.payload.repository.owner.login,
     repo: context.payload.repository.name,
@@ -130,12 +124,18 @@ export default async function issueCommentCreated(context: GitHubContext<"issue_
     return;
   }
 
-  if (!isHuman && !slashInvocation && afterMention === null) {
-    context.logger.debug({ author: context.payload.comment.user?.login, type: context.payload.comment.user?.type }, "Ignoring comment from non-human author");
+  if (!isHuman) {
+    context.logger.debug(
+      {
+        author: context.payload.comment.user?.login,
+        type: context.payload.comment.user?.type,
+      },
+      "Ignoring comment from non-human author"
+    );
     return;
   }
 
-  if (bodyLower.startsWith(`/help`)) {
+  if (afterMention === null && slashInvocation?.name.toLowerCase() === "help") {
     await postHelpCommand(context);
     return;
   }
@@ -155,16 +155,15 @@ export default async function issueCommentCreated(context: GitHubContext<"issue_
     const agentPrefixMatch = /^agent\b/i.exec(afterMention);
     if (agentPrefixMatch) {
       const task = afterMention.replace(/^agent\b/i, "").trim() || body.trim();
-      await dispatchInternalAgent(context, task, { postReply: (reply) => postReply(context, reply) });
+      await dispatchInternalAgent(context, task, {
+        postReply: (reply) => postReply(context, reply),
+      });
       return;
     }
     await commandRouter(context);
-  } else if (body.startsWith(`/`)) {
-    const slashInvocation = extractSlashCommandInvocation(body);
-    if (slashInvocation) {
-      await dispatchSlashCommand(context, slashInvocation);
-      return;
-    }
+  } else if (slashInvocation) {
+    await dispatchSlashCommand(context, slashInvocation);
+    return;
   } else if (isHuman && (await isUserHelpRequest(context))) {
     const issueAuthor = context.payload.issue.user?.login;
     context.payload.comment.body = context.payload.comment.body.replace(`@${issueAuthor}`, `@ubiquityos`);
@@ -172,21 +171,6 @@ export default async function issueCommentCreated(context: GitHubContext<"issue_
   } else {
     await callPersonalAgent(context);
   }
-}
-
-export function extractSlashCommandInvocation(text: string): SlashCommandInvocation | null {
-  const match = /^\s*\/([\w-]+)\b(.*)$/s.exec(text);
-  if (!match) return null;
-  return {
-    name: match[1],
-    rawArgs: (match[2] ?? "").trim(),
-  };
-}
-
-export function extractAfterUbiquityosMention(text: string): string | null {
-  const match = /@ubiquityos\b/i.exec(text);
-  if (!match || match.index === undefined) return null;
-  return text.slice(match.index + match[0].length).trim();
 }
 
 function listUserMentions(text: string): string[] {
@@ -252,7 +236,12 @@ async function dispatchSlashCommand(context: GitHubContext<"issue_comment.create
   }
 
   const isBotAuthor = context.payload.comment.user?.type !== "User";
-  const pluginsWithManifest: { target: string | GithubPlugin; settings: (typeof config.plugins)[string]; manifest: Manifest; manifestRef?: string }[] = [];
+  const pluginsWithManifest: {
+    target: string | GithubPlugin;
+    settings: (typeof config.plugins)[string];
+    manifest: Manifest;
+    manifestRef?: string;
+  }[] = [];
 
   for (const [pluginKey, pluginSettings] of Object.entries(config.plugins)) {
     let target: string | GithubPlugin;
@@ -267,7 +256,12 @@ async function dispatchSlashCommand(context: GitHubContext<"issue_comment.create
     }
     const { manifest, ref: manifestRef } = await getManifestResolution(context, target);
     if (!manifest?.commands) continue;
-    pluginsWithManifest.push({ target, settings: pluginSettings, manifest, manifestRef });
+    pluginsWithManifest.push({
+      target,
+      settings: pluginSettings,
+      manifest,
+      manifestRef,
+    });
   }
 
   let matchedPluginWithManifest: (typeof pluginsWithManifest)[number] | undefined;
@@ -305,7 +299,14 @@ async function dispatchSlashCommand(context: GitHubContext<"issue_comment.create
   });
   const inputs = new PluginInput(context.eventHandler, stateId, context.key, context.payload, settings, token, dispatchTarget.ref, command);
 
-  context.logger.info({ plugin, worker: dispatchTarget.kind === "worker", command }, "Will dispatch slash command plugin.");
+  context.logger.info(
+    {
+      plugin,
+      worker: dispatchTarget.kind === "worker",
+      command,
+    },
+    "Will dispatch slash command plugin."
+  );
   try {
     const { target, runUrl } = await dispatchPluginTarget({
       context,
@@ -356,7 +357,13 @@ async function postReply(context: GitHubContext<"issue_comment.created">, body: 
       repo: context.payload.repository.name,
     });
   } catch (error) {
-    context.logger.warn({ err: error, issueNumber: context.payload.issue.number }, "Failed to post reply (non-fatal)");
+    context.logger.warn(
+      {
+        err: error,
+        issueNumber: context.payload.issue.number,
+      },
+      "Failed to post reply (non-fatal)"
+    );
   }
 }
 
@@ -380,7 +387,12 @@ export function describeCommands(manifests: Manifest[]): CommandDescriptor[] {
     }
   }
 
-  setCommand({ name: "help", description: "Show all available commands and examples.", example: "/help", parameters: {} });
+  setCommand({
+    name: "help",
+    description: "Show all available commands and examples.",
+    example: "/help",
+    parameters: {},
+  });
   setCommand({
     name: "agent",
     description: "Run the full-power agent to handle complex requests.",
@@ -450,7 +462,12 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
     return;
   }
   const isBotAuthor = context.payload.comment.user?.type !== "User";
-  const pluginsWithManifest: { target: string | GithubPlugin; settings: (typeof config.plugins)[string]; manifest: Manifest; manifestRef?: string }[] = [];
+  const pluginsWithManifest: {
+    target: string | GithubPlugin;
+    settings: (typeof config.plugins)[string];
+    manifest: Manifest;
+    manifestRef?: string;
+  }[] = [];
   const manifests: Manifest[] = [];
 
   for (const [pluginKey, pluginSettings] of Object.entries(config.plugins)) {
@@ -466,7 +483,12 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
     }
     const { manifest, ref: manifestRef } = await getManifestResolution(context, target);
     if (!manifest?.commands) continue;
-    pluginsWithManifest.push({ target, settings: pluginSettings, manifest, manifestRef });
+    pluginsWithManifest.push({
+      target,
+      settings: pluginSettings,
+      manifest,
+      manifestRef,
+    });
     manifests.push(manifest);
   }
 
@@ -475,7 +497,14 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
   const labels = getIssueLabelNames(context.payload.issue.labels);
   const issueBody = truncateForRouter(context.payload.issue.body);
   const conversation = await resolveConversationKeyForContext(context, context.logger);
-  const conversationContext = conversation ? await buildConversationContext({ context, conversation, maxItems: 5, maxChars: 1600 }) : "";
+  const conversationContext = conversation
+    ? await buildConversationContext({
+        context,
+        conversation,
+        maxItems: 5,
+        maxChars: 1600,
+      })
+    : "";
   const agentMemory = await getAgentMemorySnippet({
     owner: context.payload.repository.owner.login,
     repo: context.payload.repository.name,
@@ -559,7 +588,9 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
   }
   if (decision.action === "agent") {
     const task = String(decision.task ?? "").trim() || extractAfterUbiquityosMention(context.payload.comment.body) || context.payload.comment.body.trim();
-    await dispatchInternalAgent(context, task, { postReply: (reply) => postReply(context, reply) });
+    await dispatchInternalAgent(context, task, {
+      postReply: (reply) => postReply(context, reply),
+    });
     return;
   }
 
@@ -578,7 +609,9 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
       getAgentTaskFromParameters(decision.command?.parameters) ??
       extractAfterUbiquityosMention(context.payload.comment.body) ??
       context.payload.comment.body.trim();
-    await dispatchInternalAgent(context, task, { postReply: (reply) => postReply(context, reply) });
+    await dispatchInternalAgent(context, task, {
+      postReply: (reply) => postReply(context, reply),
+    });
     return;
   }
 
@@ -613,7 +646,14 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
   });
   const inputs = new PluginInput(context.eventHandler, stateId, context.key, context.payload, settings, token, dispatchTarget.ref, command);
 
-  context.logger.info({ plugin, worker: dispatchTarget.kind === "worker", command }, "Will dispatch command plugin.");
+  context.logger.info(
+    {
+      plugin,
+      worker: dispatchTarget.kind === "worker",
+      command,
+    },
+    "Will dispatch command plugin."
+  );
   try {
     const { target, runUrl } = await dispatchPluginTarget({
       context,

--- a/src/github/handlers/pull-request-review-comment-created.ts
+++ b/src/github/handlers/pull-request-review-comment-created.ts
@@ -1,21 +1,15 @@
 import { Manifest } from "@ubiquity-os/plugin-sdk/manifest";
 import { GitHubContext } from "../github-context.ts";
 import { PluginInput } from "../types/plugin.ts";
-import { GithubPlugin, PluginSettings, parsePluginIdentifier } from "../types/plugin-configuration.ts";
+import { GithubPlugin, parsePluginIdentifier, PluginSettings } from "../types/plugin-configuration.ts";
 import { getAgentMemorySnippet } from "../utils/agent-memory.ts";
 import { shouldSkipDuplicateCommentEvent } from "../utils/comment-dedupe.ts";
+import { getCreatedCommentRouteContext } from "../utils/comment-routing.ts";
 import { getConfig } from "../utils/config.ts";
 import { getManifestResolution } from "../utils/plugins.ts";
 import { withKernelContextSettingsIfNeeded } from "../utils/plugin-dispatch-settings.ts";
 import { dispatchPluginTarget, resolvePluginDispatchTarget } from "../utils/plugin-dispatch.ts";
-import {
-  describeCommands,
-  extractAfterUbiquityosMention,
-  extractSlashCommandInvocation,
-  getIssueLabelNames,
-  parseSlashCommandParameters,
-  truncateForRouter,
-} from "./issue-comment-created.ts";
+import { describeCommands, getIssueLabelNames, parseSlashCommandParameters, truncateForRouter } from "./issue-comment-created.ts";
 import { updateRequestCommentRunUrl } from "../utils/request-comment-run-url.ts";
 import { resolveConversationKeyForContext } from "../utils/conversation-graph.ts";
 import { buildConversationContext } from "../utils/conversation-context.ts";
@@ -139,7 +133,12 @@ type ReviewCommandMatch = {
 };
 
 function resolveReviewCommandMatch(
-  pluginsWithManifest: { target: string | GithubPlugin; settings: PluginSettings; manifest: Manifest; manifestRef?: string }[],
+  pluginsWithManifest: {
+    target: string | GithubPlugin;
+    settings: PluginSettings;
+    manifest: Manifest;
+    manifestRef?: string;
+  }[],
   commandName: string
 ): ReviewCommandMatch | null {
   const requested = commandName.toLowerCase();
@@ -174,7 +173,13 @@ async function dispatchReviewCommand(
 
   const isBotAuthor = context.payload.comment.user?.type !== "User";
   if (isBotAuthor && match.settings?.skipBotEvents) {
-    context.logger.debug({ plugin: match.target, command: match.resolvedCommandName }, "Skipping review command dispatch from bot author");
+    context.logger.debug(
+      {
+        plugin: match.target,
+        command: match.resolvedCommandName,
+      },
+      "Skipping review command dispatch from bot author"
+    );
     return;
   }
 
@@ -191,7 +196,14 @@ async function dispatchReviewCommand(
   });
   const inputs = new PluginInput(context.eventHandler, stateId, context.key, context.payload, settings, token, dispatchTarget.ref, command);
 
-  context.logger.info({ plugin, worker: dispatchTarget.kind === "worker", command }, "Will dispatch command plugin from review thread.");
+  context.logger.info(
+    {
+      plugin,
+      worker: dispatchTarget.kind === "worker",
+      command,
+    },
+    "Will dispatch command plugin from review thread."
+  );
   try {
     const { target, runUrl } = await dispatchPluginTarget({
       context,
@@ -211,14 +223,15 @@ async function dispatchReviewCommand(
 }
 
 export default async function pullRequestReviewCommentCreated(context: GitHubContext<"pull_request_review_comment.created">) {
-  const body = context.payload.comment.body?.trim() ?? "";
-  const afterMention = extractAfterUbiquityosMention(body);
-  const slashInvocation = afterMention ? extractSlashCommandInvocation(afterMention) : extractSlashCommandInvocation(body);
-
-  const isHuman = context.payload.comment.user?.type === "User";
+  const routeContext = getCreatedCommentRouteContext(context.payload.comment.body, context.payload.comment.user?.type);
+  const body = routeContext.trimmedBody;
+  const { afterMention, slashInvocation, isHumanAuthor: isHuman } = routeContext;
   if (!isHuman) {
     context.logger.debug(
-      { author: context.payload.comment.user?.login, type: context.payload.comment.user?.type },
+      {
+        author: context.payload.comment.user?.login,
+        type: context.payload.comment.user?.type,
+      },
       "Ignoring review comment from non-human author"
     );
     return;
@@ -242,7 +255,9 @@ export default async function pullRequestReviewCommentCreated(context: GitHubCon
   const agentPrefixMatch = afterMention ? /^agent\b/i.exec(afterMention) : null;
   if (agentPrefixMatch && afterMention) {
     const task = afterMention.replace(/^agent\b/i, "").trim() || body;
-    await dispatchInternalAgent(context, task, { postReply: (reply) => postReplyInReviewThread(context, reply) });
+    await dispatchInternalAgent(context, task, {
+      postReply: (reply) => postReplyInReviewThread(context, reply),
+    });
     return;
   }
 
@@ -254,7 +269,12 @@ export default async function pullRequestReviewCommentCreated(context: GitHubCon
     return;
   }
 
-  const pluginsWithManifest: { target: string | GithubPlugin; settings: PluginSettings; manifest: Manifest; manifestRef?: string }[] = [];
+  const pluginsWithManifest: {
+    target: string | GithubPlugin;
+    settings: PluginSettings;
+    manifest: Manifest;
+    manifestRef?: string;
+  }[] = [];
   const manifests: Manifest[] = [];
   for (const [pluginKey, pluginSettings] of Object.entries(config.plugins)) {
     let target: string | GithubPlugin;
@@ -266,7 +286,12 @@ export default async function pullRequestReviewCommentCreated(context: GitHubCon
     }
     const { manifest, ref: manifestRef } = await getManifestResolution(context, target);
     if (!manifest?.commands) continue;
-    pluginsWithManifest.push({ target, settings: pluginSettings, manifest, manifestRef });
+    pluginsWithManifest.push({
+      target,
+      settings: pluginSettings,
+      manifest,
+      manifestRef,
+    });
     manifests.push(manifest);
   }
 
@@ -298,7 +323,14 @@ export default async function pullRequestReviewCommentCreated(context: GitHubCon
   const labels = getIssueLabelNames(hasLabels(context.payload.pull_request) ? context.payload.pull_request.labels : undefined);
   const issueBody = truncateForRouter(context.payload.pull_request.body);
   const conversation = await resolveConversationKeyForContext(context, context.logger);
-  const conversationContext = conversation ? await buildConversationContext({ context, conversation, maxItems: 5, maxChars: 1600 }) : "";
+  const conversationContext = conversation
+    ? await buildConversationContext({
+        context,
+        conversation,
+        maxItems: 5,
+        maxChars: 1600,
+      })
+    : "";
   const agentMemory = await getAgentMemorySnippet({
     owner: context.payload.repository.owner.login,
     repo: context.payload.repository.name,
@@ -363,5 +395,7 @@ export default async function pullRequestReviewCommentCreated(context: GitHubCon
 
   if (decision.action !== "agent") return;
   const task = String(decision.task ?? "").trim() || afterMention || body;
-  await dispatchInternalAgent(context, task, { postReply: (reply) => postReplyInReviewThread(context, reply) });
+  await dispatchInternalAgent(context, task, {
+    postReply: (reply) => postReplyInReviewThread(context, reply),
+  });
 }

--- a/src/github/utils/comment-routing.ts
+++ b/src/github/utils/comment-routing.ts
@@ -1,0 +1,53 @@
+export const COMMAND_RESPONSE_MARKER = '"commentKind": "command-response"';
+
+export type SlashCommandInvocation = Readonly<{
+  name: string;
+  rawArgs: string;
+}>;
+
+export type CreatedCommentRouteContext = Readonly<{
+  trimmedBody: string;
+  afterMention: string | null;
+  slashInvocation: SlashCommandInvocation | null;
+  isCommandResponse: boolean;
+  isExplicitInvocation: boolean;
+  isHumanAuthor: boolean;
+}>;
+
+export function hasCommandResponseMarker(body: string | null | undefined): boolean {
+  return typeof body === "string" && body.includes(COMMAND_RESPONSE_MARKER);
+}
+
+export function extractSlashCommandInvocation(text: string): SlashCommandInvocation | null {
+  const match = /^\s*\/([\w-]+)\b(.*)$/s.exec(text);
+  if (!match) return null;
+  return {
+    name: match[1],
+    rawArgs: (match[2] ?? "").trim(),
+  };
+}
+
+export function extractAfterUbiquityosMention(text: string): string | null {
+  const match = /^\s*@ubiquityos\b/i.exec(text);
+  if (!match || match.index === undefined) return null;
+  return text.slice(match[0].length).trim();
+}
+
+export function getCreatedCommentRouteContext(body: string | null | undefined, authorType?: string | null): CreatedCommentRouteContext {
+  const normalizedBody = typeof body === "string" ? body : "";
+  const afterMention = extractAfterUbiquityosMention(normalizedBody);
+  const slashInvocation = afterMention !== null ? extractSlashCommandInvocation(afterMention) : extractSlashCommandInvocation(normalizedBody);
+  return {
+    trimmedBody: normalizedBody.trim(),
+    afterMention,
+    slashInvocation,
+    isCommandResponse: hasCommandResponseMarker(normalizedBody),
+    isExplicitInvocation: afterMention !== null || slashInvocation !== null,
+    isHumanAuthor: authorType === "User",
+  };
+}
+
+export function shouldSkipBotInvocationDispatch(body: string | null | undefined, authorType?: string | null): boolean {
+  const routeContext = getCreatedCommentRouteContext(body, authorType);
+  return !routeContext.isHumanAuthor && (routeContext.isExplicitInvocation || routeContext.isCommandResponse);
+}

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -4,6 +4,7 @@ import { recordRequestLog } from "./request-log-store.ts";
 
 const level = process.env.LOG_LEVEL || (process.env.NODE_ENV === "production" ? "info" : "debug");
 type CustomLogLevels = "github" | "local";
+const textDecoder = new TextDecoder();
 
 const redact = {
   paths: ["token", "authorization", "*.privateKey", "*.private_key", "*.app_private_key", "*.APP_PRIVATE_KEY", "*._privateKey"],
@@ -103,6 +104,37 @@ function formatLogLine(level: string, args: unknown[], bindings: Record<string, 
   return `${base} | ${extras.join(" ")}`;
 }
 
+function normalizeChunk(chunk: string | Uint8Array): string {
+  if (typeof chunk === "string") return chunk;
+  return textDecoder.decode(chunk);
+}
+
+function selectConsoleMethod(line: string) {
+  try {
+    const parsed = JSON.parse(line) as { level?: unknown };
+    const parsedLevel = parsed.level;
+    if (typeof parsedLevel === "number") {
+      if (parsedLevel >= 50) return console.error;
+      if (parsedLevel >= 40) return console.warn;
+      if (parsedLevel >= 30) return console.info;
+    }
+  } catch {
+    // Fall back to console.log for non-JSON or partially written lines.
+  }
+  return console.log;
+}
+
+function createConsoleSyncStream(): DestinationStream {
+  return {
+    write(chunk) {
+      const line = normalizeChunk(chunk).replace(/[\r\n]+$/u, "");
+      if (!line) return true;
+      selectConsoleMethod(line).call(console, line);
+      return true;
+    },
+  } as DestinationStream;
+}
+
 const stream =
   process.env.NODE_ENV !== "production"
     ? pretty({
@@ -117,7 +149,7 @@ const stream =
           return msg;
         },
       })
-    : undefined;
+    : createConsoleSyncStream();
 
 const createLogger = pino as unknown as (options: LoggerOptions<CustomLogLevels>, stream?: DestinationStream) => Logger<CustomLogLevels>;
 

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import pino, { type DestinationStream, type Logger, type LoggerOptions } from "pino";
 import pretty from "pino-pretty";
 import { recordRequestLog } from "./request-log-store.ts";
@@ -109,17 +110,11 @@ function normalizeChunk(chunk: string | Uint8Array): string {
   return textDecoder.decode(chunk);
 }
 
-function selectConsoleMethod(line: string) {
-  try {
-    const parsed = JSON.parse(line) as { level?: unknown };
-    const parsedLevel = parsed.level;
-    if (typeof parsedLevel === "number") {
-      if (parsedLevel >= 50) return console.error;
-      if (parsedLevel >= 40) return console.warn;
-      if (parsedLevel >= 30) return console.info;
-    }
-  } catch {
-    // Fall back to console.log for non-JSON or partially written lines.
+function selectConsoleMethod(level: unknown) {
+  if (typeof level === "number") {
+    if (level >= 50) return console.error;
+    if (level >= 40) return console.warn;
+    if (level >= 30) return console.info;
   }
   return console.log;
 }
@@ -129,7 +124,13 @@ function createConsoleSyncStream(): DestinationStream {
     write(chunk) {
       const line = normalizeChunk(chunk).replace(/[\r\n]+$/u, "");
       if (!line) return true;
-      selectConsoleMethod(line).call(console, line);
+      try {
+        const parsed = JSON.parse(line) as { level?: unknown };
+        selectConsoleMethod(parsed.level).call(console, JSON.stringify(parsed, null, 2));
+      } catch {
+        // Fall back to the raw line for non-JSON or partially written chunks.
+        console.log(line);
+      }
       return true;
     },
   } as DestinationStream;

--- a/tests/comment-routing.test.ts
+++ b/tests/comment-routing.test.ts
@@ -1,0 +1,27 @@
+import { assertEquals } from "jsr:@std/assert";
+
+import { extractAfterUbiquityosMention, getCreatedCommentRouteContext, shouldSkipBotInvocationDispatch } from "../src/github/utils/comment-routing.ts";
+
+Deno.test("extractAfterUbiquityosMention: only matches explicit leading mention", () => {
+  assertEquals(extractAfterUbiquityosMention("@ubiquityos agent fix this"), "agent fix this");
+  assertEquals(extractAfterUbiquityosMention("   @ubiquityos /help"), "/help");
+  assertEquals(extractAfterUbiquityosMention("See `/query @UbiquityOS` in the help output"), null);
+});
+
+Deno.test("getCreatedCommentRouteContext: command-response output is not treated as explicit invocation", () => {
+  const routeContext = getCreatedCommentRouteContext(
+    ["| Command | Example |", "|---|---|", "| `/query` | `/query @UbiquityOS` |", "", '<!-- "commentKind": "command-response" -->'].join("\n"),
+    "Bot"
+  );
+
+  assertEquals(routeContext.afterMention, null);
+  assertEquals(routeContext.slashInvocation, null);
+  assertEquals(routeContext.isExplicitInvocation, false);
+  assertEquals(routeContext.isCommandResponse, true);
+});
+
+Deno.test("shouldSkipBotInvocationDispatch: blocks bot invocations but not generic bot activity", () => {
+  assertEquals(shouldSkipBotInvocationDispatch("@ubiquityos agent implement this", "Bot"), true);
+  assertEquals(shouldSkipBotInvocationDispatch("/help", "Bot"), true);
+  assertEquals(shouldSkipBotInvocationDispatch("Build finished successfully.", "Bot"), false);
+});

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -3,7 +3,6 @@ import { assertEquals } from "jsr:@std/assert";
 
 import { GitHubEventHandler } from "../src/github/github-event-handler.ts";
 import { bindHandlers, type HandlerDeps } from "../src/github/handlers/index.ts";
-import { logger } from "../src/logger/logger.ts";
 import { FakeWebhooks } from "./test-utils/fake-webhooks.ts";
 
 const TEST_APP_ID = "1";
@@ -11,22 +10,37 @@ const TEST_PRIVATE_KEY = "test-private-key";
 const TEST_WEBHOOK_SECRET = "test-secret";
 const TEST_MODEL = "test-model";
 const MOCK_TOKEN = "mock-token";
+let nextEventCommentId = 100;
+const testLogger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  github: () => {},
+};
 
-function issueCommentCreatedEvent(commentBody: string): EmitterWebhookEvent {
+function issueCommentCreatedEvent(commentBody: string, authorType: "User" | "Bot" = "User"): EmitterWebhookEvent {
+  const login = authorType === "User" ? "test-user" : "ubiquity-os-beta[bot]";
+  const commentId = nextEventCommentId++;
   return {
     id: "evt_1",
     name: "issue_comment",
     payload: {
       action: "created",
       installation: { id: 1 },
-      sender: { login: "test-user", type: "User" },
+      sender: { login, type: authorType },
       comment: {
-        id: 101,
+        id: commentId,
         body: commentBody,
-        user: { login: "test-user", type: "User" },
-        html_url: "https://github.com/test-user/test-repo/issues/1#issuecomment-101",
+        user: { login, type: authorType },
+        html_url: `https://github.com/test-user/test-repo/issues/1#issuecomment-${commentId}`,
       },
-      issue: { number: 1, user: { login: "test-user" }, html_url: "https://github.com/test-user/test-repo/issues/1" },
+      issue: {
+        number: 1,
+        user: { login: "test-user" },
+        html_url: "https://github.com/test-user/test-repo/issues/1",
+      },
       repository: {
         id: 123,
         name: "test-repo",
@@ -37,35 +51,76 @@ function issueCommentCreatedEvent(commentBody: string): EmitterWebhookEvent {
   } as EmitterWebhookEvent;
 }
 
-Deno.test("handleEvent: continues dispatching plugins if one throws", async () => {
-  const pluginA = "https://plugin-a.internal";
-  const pluginB = "https://plugin-b.internal";
+function pullRequestReviewCommentCreatedEvent(commentBody: string, authorType: "User" | "Bot" = "User"): EmitterWebhookEvent {
+  const login = authorType === "User" ? "test-user" : "ubiquity-os-beta[bot]";
+  const commentId = nextEventCommentId++;
+  return {
+    id: "evt_review_1",
+    name: "pull_request_review_comment",
+    payload: {
+      action: "created",
+      installation: { id: 1 },
+      sender: { login, type: authorType },
+      comment: {
+        id: commentId,
+        body: commentBody,
+        user: { login, type: authorType },
+        html_url: `https://github.com/test-user/test-repo/pull/1#discussion_r${commentId}`,
+      },
+      pull_request: {
+        number: 1,
+        title: "Test PR",
+        body: "PR body",
+        html_url: "https://github.com/test-user/test-repo/pull/1",
+        labels: [],
+        user: { login: "test-user" },
+      },
+      repository: {
+        id: 123,
+        name: "test-repo",
+        full_name: "test-user/test-repo",
+        owner: { login: "test-user", id: 456 },
+      },
+    },
+  } as unknown as EmitterWebhookEvent;
+}
 
+function getEventKey(event: EmitterWebhookEvent): string {
+  if (event.name === "issue_comment") return "issue_comment.created";
+  if (event.name === "pull_request_review_comment") {
+    return "pull_request_review_comment.created";
+  }
+  return `${event.name}.${String((event.payload as { action?: unknown }).action ?? "")}`;
+}
+
+function createEventHandler() {
   const eventHandler = new GitHubEventHandler({
     environment: "production",
     webhookSecret: TEST_WEBHOOK_SECRET,
     appId: TEST_APP_ID,
     privateKey: TEST_PRIVATE_KEY,
     llm: TEST_MODEL,
+    logger: testLogger as never,
     createWebhooks: (options) => new FakeWebhooks(options) as unknown as never,
   });
   eventHandler.getToken = async () => MOCK_TOKEN;
-
-  const fakeEvent = issueCommentCreatedEvent("/foo");
-  eventHandler.transformEvent = () =>
+  eventHandler.transformEvent = (event) =>
     ({
       id: "state_1",
-      key: "issue_comment.created",
+      key: getEventKey(event),
       octokit: {},
       eventHandler,
-      payload: fakeEvent.payload,
-      logger,
+      payload: event.payload,
+      logger: testLogger,
     }) as never;
+  return eventHandler;
+}
 
-  const dispatches: Array<{ plugin: string; eventName: string }> = [];
-
+function createDispatchDeps(dispatches: Array<{ plugin: string; eventName: string }>, options?: { throwOnFirstDispatch?: boolean }): Partial<HandlerDeps> {
+  const pluginA = "https://plugin-a.internal";
+  const pluginB = "https://plugin-b.internal";
   let dispatchAttempt = 0;
-  const deps: Partial<HandlerDeps> = {
+  return {
     getKernelCommit: async () => "deadbeef",
     getConfig: async () =>
       ({
@@ -79,21 +134,49 @@ Deno.test("handleEvent: continues dispatching plugins if one throws", async () =
       void plugins;
       if (event === ("kernel.plugin_error" as never)) return [] as never;
       return [
-        { key: pluginA, target: pluginA, settings: { skipBotEvents: false, with: {} } },
-        { key: pluginB, target: pluginB, settings: { skipBotEvents: false, with: {} } },
+        {
+          key: pluginA,
+          target: pluginA,
+          settings: { skipBotEvents: false, with: {} },
+        },
+        {
+          key: pluginB,
+          target: pluginB,
+          settings: { skipBotEvents: false, with: {} },
+        },
       ] as never;
     },
     getManifest: async () => ({ name: "plugin" }) as never,
-    resolvePluginDispatchTarget: async ({ plugin }) => ({ kind: "worker", targetUrl: String(plugin), ref: String(plugin) }) as never,
+    resolvePluginDispatchTarget: async ({ plugin }) =>
+      ({
+        kind: "worker",
+        targetUrl: String(plugin),
+        ref: String(plugin),
+      }) as never,
     dispatchPluginTarget: async ({ plugin, pluginInput }) => {
-      dispatches.push({ plugin: typeof plugin === "string" ? plugin : `${plugin.owner}/${plugin.repo}`, eventName: String(pluginInput.eventName) });
+      dispatches.push({
+        plugin: typeof plugin === "string" ? plugin : `${plugin.owner}/${plugin.repo}`,
+        eventName: String(pluginInput.eventName),
+      });
       dispatchAttempt += 1;
-      if (dispatchAttempt === 1) {
+      if (options?.throwOnFirstDispatch && dispatchAttempt === 1) {
         throw new Error("Test induced first call failure");
       }
-      return { target: { kind: "worker", targetUrl: "ok", ref: "ok" } } as never;
+      return {
+        target: { kind: "worker", targetUrl: "ok", ref: "ok" },
+      } as never;
     },
   };
+}
+
+Deno.test("handleEvent: continues dispatching plugins if one throws", async () => {
+  const pluginA = "https://plugin-a.internal";
+  const pluginB = "https://plugin-b.internal";
+
+  const eventHandler = createEventHandler();
+  const fakeEvent = issueCommentCreatedEvent("/foo");
+  const dispatches: Array<{ plugin: string; eventName: string }> = [];
+  const deps = createDispatchDeps(dispatches, { throwOnFirstDispatch: true });
 
   bindHandlers(eventHandler, deps);
   await (eventHandler.webhooks as unknown as FakeWebhooks<unknown>).receive(fakeEvent);
@@ -101,4 +184,48 @@ Deno.test("handleEvent: continues dispatching plugins if one throws", async () =
   assertEquals(dispatches.length, 2);
   assertEquals(dispatches[0].plugin, pluginA);
   assertEquals(dispatches[1].plugin, pluginB);
+});
+
+Deno.test("handleEvent: skips global dispatch for bot-authored command-response issue comments", async () => {
+  const eventHandler = createEventHandler();
+  const fakeEvent = issueCommentCreatedEvent('| `/query` | `/query @UbiquityOS` |\n\n<!-- "commentKind": "command-response" -->', "Bot");
+  const dispatches: Array<{ plugin: string; eventName: string }> = [];
+
+  bindHandlers(eventHandler, createDispatchDeps(dispatches));
+  await (eventHandler.webhooks as unknown as FakeWebhooks<unknown>).receive(fakeEvent);
+
+  assertEquals(dispatches.length, 0);
+});
+
+Deno.test("handleEvent: skips global dispatch for bot-authored invocation issue comments", async () => {
+  const eventHandler = createEventHandler();
+  const fakeEvent = issueCommentCreatedEvent("@ubiquityos agent implement this", "Bot");
+  const dispatches: Array<{ plugin: string; eventName: string }> = [];
+
+  bindHandlers(eventHandler, createDispatchDeps(dispatches));
+  await (eventHandler.webhooks as unknown as FakeWebhooks<unknown>).receive(fakeEvent);
+
+  assertEquals(dispatches.length, 0);
+});
+
+Deno.test("handleEvent: still dispatches generic bot issue comments when plugins allow bot events", async () => {
+  const eventHandler = createEventHandler();
+  const fakeEvent = issueCommentCreatedEvent("Build finished successfully.", "Bot");
+  const dispatches: Array<{ plugin: string; eventName: string }> = [];
+
+  bindHandlers(eventHandler, createDispatchDeps(dispatches));
+  await (eventHandler.webhooks as unknown as FakeWebhooks<unknown>).receive(fakeEvent);
+
+  assertEquals(dispatches.length, 2);
+});
+
+Deno.test("handleEvent: skips global dispatch for bot-authored invocation review comments", async () => {
+  const eventHandler = createEventHandler();
+  const fakeEvent = pullRequestReviewCommentCreatedEvent("@ubiquityos agent implement this", "Bot");
+  const dispatches: Array<{ plugin: string; eventName: string }> = [];
+
+  bindHandlers(eventHandler, createDispatchDeps(dispatches));
+  await (eventHandler.webhooks as unknown as FakeWebhooks<unknown>).receive(fakeEvent);
+
+  assertEquals(dispatches.length, 0);
 });

--- a/tests/issue-comment-created.test.ts
+++ b/tests/issue-comment-created.test.ts
@@ -1,0 +1,322 @@
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
+
+import type { GitHubContext } from "../src/github/github-context.ts";
+import issueCommentCreated from "../src/github/handlers/issue-comment-created.ts";
+import { CONFIG_FULL_PATH } from "../src/github/utils/config.ts";
+import { stubFetch } from "./test-utils/fetch-stub.ts";
+
+const ISSUE_COMMENT_CREATED = "issue_comment.created";
+let nextCommentId = 1000;
+
+function createLogger() {
+  return {
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    github: () => {},
+  };
+}
+
+function createAuthenticatedOctokit(workflowDispatchCalls: unknown[]) {
+  return {
+    rest: {
+      repos: {
+        get: async () => ({ data: { default_branch: "main" } }),
+      },
+      actions: {
+        createWorkflowDispatch: async (args: unknown) => {
+          workflowDispatchCalls.push(args);
+          return {};
+        },
+        listWorkflowRuns: async () => ({
+          data: {
+            workflow_runs: [
+              {
+                html_url: "https://github.com/ubiquity-os/ubiquity-os-kernel/actions/runs/1",
+                created_at: new Date().toISOString(),
+                event: "workflow_dispatch",
+                head_branch: "main",
+              },
+            ],
+          },
+        }),
+      },
+    },
+  };
+}
+
+function createBaseContext(
+  body: string,
+  authorType: "User" | "Bot",
+  options?: {
+    commentId?: number;
+    octokit?: Record<string, unknown>;
+    eventHandler?: Record<string, unknown>;
+  }
+): GitHubContext<"issue_comment.created"> {
+  const workflowDispatchCalls: unknown[] = [];
+  const logger = createLogger();
+  const authorLogin = authorType === "User" ? "test-user" : "ubiquity-os-beta[bot]";
+  const commentId = options?.commentId ?? nextCommentId++;
+  const authenticatedOctokit = createAuthenticatedOctokit(workflowDispatchCalls);
+  const octokitOverrides = options?.octokit ?? {};
+  const overriddenRest = (octokitOverrides.rest ?? {}) as Record<string, unknown>;
+  const eventHandlerOverrides = options?.eventHandler ?? {};
+  const overriddenAgent = (eventHandlerOverrides.agent ?? {}) as Record<string, unknown>;
+
+  const octokit = {
+    ...octokitOverrides,
+    rest: {
+      reactions: {
+        createForIssueComment: async () => ({}),
+        ...(overriddenRest.reactions as Record<string, unknown> | undefined),
+      },
+      issues: {
+        createComment: async () => ({}),
+        updateComment: async () => ({}),
+        get: async () => ({ data: { body: "", body_html: "" } }),
+        listComments: async () => ({ data: [] }),
+        ...(overriddenRest.issues as Record<string, unknown> | undefined),
+      },
+      pulls: {
+        updateReviewComment: async () => ({}),
+        ...(overriddenRest.pulls as Record<string, unknown> | undefined),
+      },
+      apps: {
+        getRepoInstallation: async () => ({ data: { id: 999 } }),
+        ...(overriddenRest.apps as Record<string, unknown> | undefined),
+      },
+      repos: {
+        getCollaboratorPermissionLevel: async () => ({
+          data: { role_name: "admin" },
+        }),
+        getContent: async () => ({ data: null }),
+        ...(overriddenRest.repos as Record<string, unknown> | undefined),
+      },
+    },
+    paginate: octokitOverrides.paginate ?? (async () => []),
+  };
+
+  const eventHandler = {
+    environment: "production",
+    logger,
+    ...eventHandlerOverrides,
+    getToken: eventHandlerOverrides.getToken ?? (async () => "ghs_test_token"),
+    getAuthenticatedOctokit: eventHandlerOverrides.getAuthenticatedOctokit ?? (() => authenticatedOctokit),
+    signPayload: eventHandlerOverrides.signPayload ?? (async () => "signature"),
+    getKernelPublicKeyPem: eventHandlerOverrides.getKernelPublicKeyPem ?? (() => ""),
+    kernelRefreshUrl: eventHandlerOverrides.kernelRefreshUrl ?? "",
+    kernelRefreshIntervalSeconds: eventHandlerOverrides.kernelRefreshIntervalSeconds ?? 60,
+    agent: {
+      owner: "ubiquity-os",
+      repo: "ubiquity-os-kernel",
+      workflowId: "agent.yml",
+      ref: "main",
+      ...overriddenAgent,
+    },
+  };
+
+  return {
+    id: "",
+    key: ISSUE_COMMENT_CREATED,
+    name: ISSUE_COMMENT_CREATED,
+    payload: {
+      action: "created",
+      installation: { id: 1 },
+      sender: { login: authorLogin, type: authorType },
+      comment: {
+        id: commentId,
+        node_id: `node-${commentId}`,
+        body,
+        html_url: `https://github.com/ubiquity-os/ubiquity-os-kernel/issues/331#issuecomment-${commentId}`,
+        user: {
+          login: authorLogin,
+          type: authorType,
+          id: authorType === "User" ? 1 : 2,
+        },
+        author_association: "MEMBER",
+      },
+      issue: {
+        number: 331,
+        node_id: "I_kwDOTest",
+        title: "Test issue",
+        html_url: "https://github.com/ubiquity-os/ubiquity-os-kernel/issues/331",
+        created_at: new Date(0).toISOString(),
+        user: { login: "issue-owner", id: 42 },
+      },
+      repository: {
+        id: 123,
+        name: "ubiquity-os-kernel",
+        full_name: "ubiquity-os/ubiquity-os-kernel",
+        owner: { login: "ubiquity-os", id: 456 },
+      },
+    } as GitHubContext<"issue_comment.created">["payload"],
+    logger: logger as never,
+    octokit: octokit as never,
+    eventHandler: eventHandler as never,
+    llm: "",
+  };
+}
+
+Deno.test("issueCommentCreated: routes human /help to help output", async () => {
+  const originalGitRevision = Deno.env.get("GIT_REVISION");
+  Deno.env.set("GIT_REVISION", "deadbeef");
+
+  const fetchStub = stubFetch({
+    "https://plugin-a.internal/manifest.json": new Response(
+      JSON.stringify({
+        name: "plugin-a",
+        short_name: "plugin-a",
+        homepage_url: "",
+        description: "plugin-a for tests",
+        "ubiquity:listeners": [ISSUE_COMMENT_CREATED],
+        commands: {
+          foo: { description: "foo command", "ubiquity:example": "/foo bar" },
+        },
+      }),
+      { headers: { "content-type": "application/json" } }
+    ),
+    "https://plugin-a.internal//manifest.json": new Response(
+      JSON.stringify({
+        name: "plugin-a",
+        short_name: "plugin-a",
+        homepage_url: "",
+        description: "plugin-a for tests",
+        "ubiquity:listeners": [ISSUE_COMMENT_CREATED],
+        commands: {
+          foo: { description: "foo command", "ubiquity:example": "/foo bar" },
+        },
+      }),
+      { headers: { "content-type": "application/json" } }
+    ),
+  });
+
+  const createCommentCalls: Array<{ body: string }> = [];
+  const context = createBaseContext("/help", "User", {
+    octokit: {
+      rest: {
+        issues: {
+          createComment: async ({ body }: { body: string }) => {
+            createCommentCalls.push({ body });
+            return {};
+          },
+          updateComment: async () => ({}),
+          get: async () => ({ data: { body: "", body_html: "" } }),
+          listComments: async () => ({ data: [] }),
+        },
+        repos: {
+          getCollaboratorPermissionLevel: async () => ({
+            data: { role_name: "admin" },
+          }),
+          getContent: async ({ path }: { path: string }) => {
+            if (path === CONFIG_FULL_PATH) {
+              return {
+                data: `
+                plugins:
+                  https://plugin-a.internal:
+                    with: {}
+                `,
+              };
+            }
+            return { data: null };
+          },
+        },
+      },
+    },
+  });
+
+  try {
+    await issueCommentCreated(context);
+  } finally {
+    fetchStub.restore();
+    if (originalGitRevision === undefined) {
+      Deno.env.delete("GIT_REVISION");
+    } else {
+      Deno.env.set("GIT_REVISION", originalGitRevision);
+    }
+  }
+
+  assertEquals(createCommentCalls.length, 1);
+  assertStringIncludes(createCommentCalls[0].body, "| `/help` | List all available commands. | `/help` |");
+});
+
+Deno.test("issueCommentCreated: ignores bot-authored /help comments", async () => {
+  const createCommentCalls: unknown[] = [];
+  const context = createBaseContext("/help", "Bot", {
+    octokit: {
+      rest: {
+        issues: {
+          createComment: async (args: unknown) => {
+            createCommentCalls.push(args);
+            return {};
+          },
+          updateComment: async () => ({}),
+          get: async () => ({ data: { body: "", body_html: "" } }),
+          listComments: async () => ({ data: [] }),
+        },
+      },
+    },
+  });
+
+  await issueCommentCreated(context);
+
+  assertEquals(createCommentCalls.length, 0);
+});
+
+Deno.test("issueCommentCreated: dispatches internal agent for explicit human mention", async () => {
+  const workflowDispatchCalls: unknown[] = [];
+  const reactionCalls: unknown[] = [];
+  const context = createBaseContext("@ubiquityos agent implement the fix", "User", {
+    octokit: {
+      rest: {
+        reactions: {
+          createForIssueComment: async (args: unknown) => {
+            reactionCalls.push(args);
+            return {};
+          },
+        },
+        issues: {
+          createComment: async () => ({}),
+          updateComment: async () => ({}),
+          get: async () => ({ data: { body: "", body_html: "" } }),
+          listComments: async () => ({ data: [] }),
+        },
+      },
+    },
+    eventHandler: {
+      getAuthenticatedOctokit: () => createAuthenticatedOctokit(workflowDispatchCalls),
+    },
+  });
+
+  await issueCommentCreated(context);
+
+  assertEquals(reactionCalls.length, 1);
+  assertEquals(workflowDispatchCalls.length, 1);
+});
+
+Deno.test("issueCommentCreated: ignores bot-authored agent mentions", async () => {
+  const workflowDispatchCalls: unknown[] = [];
+  const reactionCalls: unknown[] = [];
+  const context = createBaseContext("@ubiquityos agent implement the fix", "Bot", {
+    octokit: {
+      rest: {
+        reactions: {
+          createForIssueComment: async (args: unknown) => {
+            reactionCalls.push(args);
+            return {};
+          },
+        },
+      },
+    },
+    eventHandler: {
+      getAuthenticatedOctokit: () => createAuthenticatedOctokit(workflowDispatchCalls),
+    },
+  });
+
+  await issueCommentCreated(context);
+
+  assertEquals(reactionCalls.length, 0);
+  assertEquals(workflowDispatchCalls.length, 0);
+});


### PR DESCRIPTION
## Summary
- add a shared created-comment routing helper for explicit slash/mention entrypoints and command-response detection
- ignore bot-authored slash/mention routing in the issue and PR review comment handlers
- skip global plugin dispatch for bot-authored invocation or command-response comments while preserving generic bot activity for plugins that explicitly allow bot events
- add focused parsing, handler, and dispatch regression tests for `/help`, explicit `@ubiquityos agent ...`, and bot-authored command-response comments

## Root Cause
- the issue comment routing path treated any `@ubiquityos` mention in the comment body as an invocation, even when it only appeared inside bot-authored help output or command examples
- the generic `onAny` dispatch path still forwarded bot-authored invocation-like comments before the specific handlers could ignore them

## Validation
- `deno test --allow-env --allow-sys tests/comment-routing.test.ts tests/issue-comment-created.test.ts tests/commands.test.ts tests/personal-agent.test.ts tests/dispatch.test.ts`

Closes #331

## E2E
- posted /help with no further back and forth comment from the bot https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/340#issuecomment-4273040600