### PR TITLE
feat: add /version command for kernel version and commit info

### DIFF
--- a/src/github/handlers/help-command.ts
+++ b/src/github/handlers/help-command.ts
@@ -97,6 +97,7 @@ export async function postHelpCommand(context: GitHubContext<"issue_comment.crea
   context.logger.info({ pluginCount: Object.keys(configuration?.plugins || {}).length }, "Processing help command");
 
   commandRows.set("help", "| `/help` | List all available commands. | `/help` |");
+  commandRows.set("version", "| `/version` | Show kernel version and commit hash. | `/version` |");
 
   for (const [pluginKey] of Object.entries(configuration?.plugins || {})) {
     let plugin: string | GithubPlugin;

--- a/src/github/handlers/issue-comment-created.ts
+++ b/src/github/handlers/issue-comment-created.ts
@@ -9,6 +9,7 @@ import { getManifestResolution } from "../utils/plugins.ts";
 import { withKernelContextSettingsIfNeeded } from "../utils/plugin-dispatch-settings.ts";
 import { dispatchPluginTarget, resolvePluginDispatchTarget } from "../utils/plugin-dispatch.ts";
 import { postHelpCommand } from "./help-command.ts";
+import { postVersionCommand } from "./version-command.ts";
 import { dispatchInternalAgent } from "./internal-agent.ts";
 import { buildRouterPrompt } from "./router-prompt.ts";
 import { callPersonalAgent } from "./personal-agent.ts";
@@ -140,6 +141,11 @@ export default async function issueCommentCreated(context: GitHubContext<"issue_
     return;
   }
 
+  if (bodyLower.startsWith(`/version`)) {
+    await postVersionCommand(context);
+    return;
+  }
+
   if (afterMention !== null) {
     if (context.payload.comment.user?.type === "User") {
       await addReactionEyes(context);
@@ -147,6 +153,10 @@ export default async function issueCommentCreated(context: GitHubContext<"issue_
     if (slashInvocation) {
       if (slashInvocation.name === "help") {
         await postHelpCommand(context);
+        return;
+      }
+      if (slashInvocation.name === "version") {
+        await postVersionCommand(context);
         return;
       }
       await dispatchSlashCommand(context, slashInvocation);
@@ -571,6 +581,10 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
 
   if (commandName === "help") {
     await postHelpCommand(context);
+    return;
+  }
+  if (commandName === "version") {
+    await postVersionCommand(context);
     return;
   }
   if (commandName === "agent") {

--- a/src/github/handlers/version-command.ts
+++ b/src/github/handlers/version-command.ts
@@ -1,0 +1,47 @@
+import { GitHubContext } from "../github-context.ts";
+import { getKernelCommit } from "../utils/kernel-metadata.ts";
+import { getConfigFullPathForEnvironment } from "../utils/config.ts";
+
+const VERSION_RESPONSE_MARKER = '"commentKind": "version-response"';
+
+export async function postVersionCommand(context: GitHubContext<"issue_comment.created">) {
+  const commitHash = await getKernelCommit();
+  const environment = context.eventHandler.environment;
+  const configPath = getConfigFullPathForEnvironment(environment);
+
+  // Try to read version from package.json
+  let kernelVersion = "unknown";
+  try {
+    const fs = await import("node:fs/promises");
+    const pkg = await fs.readFile("package.json", "utf8");
+    const { version } = JSON.parse(pkg);
+    if (version) kernelVersion = version;
+  } catch {
+    // fallback to unknown
+  }
+
+  const body = [
+    `| Field | Value |`,
+    `|---|---|`,
+    `| **Kernel Version** | \`${kernelVersion}\` |`,
+    `| **Commit** | \`${commitHash}\` |`,
+    `| **Environment** | \`${environment}\` |`,
+    `| **Config** | \`${configPath}\` |`,
+    ``,
+    `###### UbiquityOS Kernel [${commitHash}](https://github.com/ubiquity-os/ubiquity-os-kernel/commit/${commitHash})`,
+  ].join("\n");
+
+  const bodyWithMarker = appendVersionMarker(body);
+
+  await context.octokit.rest.issues.createComment({
+    body: bodyWithMarker,
+    issue_number: context.payload.issue.number,
+    owner: context.payload.repository.owner.login,
+    repo: context.payload.repository.name,
+  });
+}
+
+function appendVersionMarker(body: string): string {
+  if (body.includes(VERSION_RESPONSE_MARKER)) return body;
+  return `${body}\n\n<!-- ${VERSION_RESPONSE_MARKER} -->`;
+}


### PR DESCRIPTION
## Summary
Implements a new `/version` slash command for the UbiquityOS kernel as part of the General Improvements bounty (devpool-directory#5902 / ubiquity-os-kernel#300).

## Changes
- **New handler**: `src/github/handlers/version-command.ts`
  - `postVersionCommand()` posts a table with kernel version, commit hash, environment, and config path
  - Uses `getKernelCommit()` for commit hash (same as /help footer)
  - Reads version from `package.json`
  - Adds a `<!-- commentKind: version-response -->` marker for deduplication

- **Routing additions** in `issue-comment-created.ts`:
  - Direct comment: `/version` → `postVersionCommand`
  - Mention: `@ubiquityos version` → `postVersionCommand`
  - Router decision: `commandName === 'version'` → `postVersionCommand`

- **Help listing** in `help-command.ts`:
  - Registers `/version` with description and example in the /help table

## Example Output
```
| Field | Value |
|---|---|
| **Kernel Version** | `7.3.0` |
| **Commit** | `5ee3a97` |
| **Environment** | `development` |
| **Config** | `ubiquity-os.config.development.yml` |

###### UbiquityOS Kernel [5ee3a97](https://github.com/ubiquity-os/ubiquity-os-kernel/commit/5ee3a97)
```

## Test Plan
- [ ] `/version` command responds with correct version info
- [ ] `@ubiquityos version` mention works
- [ ] `/help` includes `/version` in the command table
- [ ] Command is properly de-duplicated (marker prevents duplicate posts)

Closes ubiquity-os/ubiquity-os-kernel#300