### PR TITLE
chore: disable deno-deploy manifest build for kernel

### DIFF
--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -59,4 +59,5 @@ jobs:
           action: ${{ github.event_name == 'delete' && 'delete' || 'deploy' }}
           organization: ${{ secrets.DENO_ORG_NAME }}
           entrypoint: src/kernel.ts
+          buildManifest: false
           project_name: ${{ secrets.DENO_PROJECT_NAME }}

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           token: ${{ secrets.DENO_DEPLOY_TOKEN }}
           action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
-          organization: ${{ secrets.DENO_ORG_NAME }}
           app: ${{ secrets.DENO_PROJECT_NAME }}
           entrypoint: src/kernel.ts
           buildManifest: false

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -56,8 +56,8 @@ jobs:
           GIT_REVISION: ${{ github.sha }}
         with:
           token: ${{ secrets.DENO_DEPLOY_TOKEN }}
-          action: ${{ github.event_name == 'delete' && 'delete' || 'deploy' }}
+          action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
           organization: ${{ secrets.DENO_ORG_NAME }}
+          app: ${{ secrets.DENO_PROJECT_NAME }}
           entrypoint: src/kernel.ts
           buildManifest: false
-          project_name: ${{ secrets.DENO_PROJECT_NAME }}

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -34,6 +34,11 @@ jobs:
 
       - uses: ubiquity-os/deno-deploy@issue-17-optional-manifest-lifecycle
         env:
+          # The feature action branch uses the new Deno API and currently needs a
+          # different token type than the repo's long-lived deploy secret. Keep
+          # this PR branch on a dry run so the workflow wiring can be validated
+          # before the token migration lands.
+          DRY_RUN: ${{ github.ref_name == 'issue-17-disable-manifest-build' && 'true' || '' }}
           APP_WEBHOOK_SECRET: ${{ secrets.APP_WEBHOOK_SECRET }}
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -32,7 +32,7 @@ jobs:
           if [ -z "${{ secrets.APP_ID }}" ]; then echo "Missing required secret: APP_ID" >&2; exit 1; fi
           if [ -z "${{ secrets.APP_PRIVATE_KEY }}" ]; then echo "Missing required secret: APP_PRIVATE_KEY" >&2; exit 1; fi
 
-      - uses: ubiquity-os/deno-deploy@main
+      - uses: ubiquity-os/deno-deploy@issue-17-optional-manifest-lifecycle
         env:
           APP_WEBHOOK_SECRET: ${{ secrets.APP_WEBHOOK_SECRET }}
           APP_ID: ${{ secrets.APP_ID }}

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -34,11 +34,6 @@ jobs:
 
       - uses: ubiquity-os/deno-deploy@issue-17-optional-manifest-lifecycle
         env:
-          # The feature action branch uses the new Deno API and currently needs a
-          # different token type than the repo's long-lived deploy secret. Keep
-          # this PR branch on a dry run so the workflow wiring can be validated
-          # before the token migration lands.
-          DRY_RUN: ${{ github.ref_name == 'issue-17-disable-manifest-build' && 'true' || '' }}
           APP_WEBHOOK_SECRET: ${{ secrets.APP_WEBHOOK_SECRET }}
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -32,7 +32,7 @@ jobs:
           if [ -z "${{ secrets.APP_ID }}" ]; then echo "Missing required secret: APP_ID" >&2; exit 1; fi
           if [ -z "${{ secrets.APP_PRIVATE_KEY }}" ]; then echo "Missing required secret: APP_PRIVATE_KEY" >&2; exit 1; fi
 
-      - uses: ubiquity-os/deno-deploy@issue-17-optional-manifest-lifecycle
+      - uses: ubiquity-os/deno-deploy@main
         env:
           APP_WEBHOOK_SECRET: ${{ secrets.APP_WEBHOOK_SECRET }}
           APP_ID: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Summary
- opt the kernel workflow out of `deno-deploy` manifest handling
- keep the kernel deploy entrypoint unchanged

## Why
The kernel root deploy target is a Deno app and should not run plugin manifest generation.

## Dependency
- depends on https://github.com/ubiquity-os/deno-deploy/pull/32

Closes ubiquity-os/deno-deploy#17