### PR TITLE
fix: handle null/undefined config.plugins in commandRouter

### DIFF
--- a/src/github/handlers/issue-comment-created.ts
+++ b/src/github/handlers/issue-comment-created.ts
@@ -461,6 +461,10 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
     context.logger.debug("No configuration was found");
     return;
   }
+  if (!config.plugins || typeof config.plugins !== "object") {
+    context.logger.debug("No plugins found in configuration");
+    return;
+  }
   const isBotAuthor = context.payload.comment.user?.type !== "User";
   const pluginsWithManifest: {
     target: string | GithubPlugin;


### PR DESCRIPTION
## Problem

When `config.plugins` is null or undefined, `Object.entries(config.plugins)` throws:
```
AggregateError: Cannot convert undefined or null to object
    TypeError: Cannot convert undefined or null to object
        at Object.keys (<anonymous>)
        at commandRouter
```

This crashes the entire event handler and prevents other plugins from being processed.

## Solution

Add a guard check for `config.plugins` before iterating:
- Check if `config.plugins` exists and is an object
- If not, log a debug message and return early
- This prevents the crash and allows the system to handle invalid configurations gracefully

Fixes ubiquity-os-kernel#287