### PR TITLE
Guard command routing for empty plugin config

### DIFF
--- a/src/github/handlers/issue-comment-created.ts
+++ b/src/github/handlers/issue-comment-created.ts
@@ -1,7 +1,7 @@
 import { Manifest } from "@ubiquity-os/plugin-sdk/manifest";
 import { GitHubContext } from "../github-context.ts";
 import { PluginInput } from "../types/plugin.ts";
-import { GithubPlugin, parsePluginIdentifier } from "../types/plugin-configuration.ts";
+import { GithubPlugin, parsePluginIdentifier, type PluginSettings } from "../types/plugin-configuration.ts";
 import { getAgentMemorySnippet, listAgentMemoryEntries, upsertAgentRunMemory } from "../utils/agent-memory.ts";
 import { extractAfterUbiquityosMention, getCreatedCommentRouteContext, type SlashCommandInvocation } from "../utils/comment-routing.ts";
 import { shouldSkipDuplicateCommentEvent } from "../utils/comment-dedupe.ts";
@@ -236,14 +236,15 @@ async function dispatchSlashCommand(context: GitHubContext<"issue_comment.create
   }
 
   const isBotAuthor = context.payload.comment.user?.type !== "User";
+  const pluginEntries = Object.entries(config.plugins ?? {}) as [string, PluginSettings][];
   const pluginsWithManifest: {
     target: string | GithubPlugin;
-    settings: (typeof config.plugins)[string];
+    settings: PluginSettings;
     manifest: Manifest;
     manifestRef?: string;
   }[] = [];
 
-  for (const [pluginKey, pluginSettings] of Object.entries(config.plugins)) {
+  for (const [pluginKey, pluginSettings] of pluginEntries) {
     let target: string | GithubPlugin;
     try {
       target = parsePluginIdentifier(pluginKey);
@@ -462,15 +463,16 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
     return;
   }
   const isBotAuthor = context.payload.comment.user?.type !== "User";
+  const pluginEntries = Object.entries(config.plugins ?? {}) as [string, PluginSettings][];
   const pluginsWithManifest: {
     target: string | GithubPlugin;
-    settings: (typeof config.plugins)[string];
+    settings: PluginSettings;
     manifest: Manifest;
     manifestRef?: string;
   }[] = [];
   const manifests: Manifest[] = [];
 
-  for (const [pluginKey, pluginSettings] of Object.entries(config.plugins)) {
+  for (const [pluginKey, pluginSettings] of pluginEntries) {
     let target: string | GithubPlugin;
     try {
       target = parsePluginIdentifier(pluginKey);

--- a/tests/issue-comment-created.test.ts
+++ b/tests/issue-comment-created.test.ts
@@ -265,6 +265,99 @@ Deno.test("issueCommentCreated: ignores bot-authored /help comments", async () =
   assertEquals(createCommentCalls.length, 0);
 });
 
+Deno.test("issueCommentCreated: ignores slash commands when config plugins is empty", async () => {
+  const workflowDispatchCalls: unknown[] = [];
+  const context = createBaseContext("/foo bar", "User", {
+    octokit: {
+      rest: {
+        issues: {
+          createComment: async () => ({}),
+          updateComment: async () => ({}),
+          get: async () => ({ data: { body: "", body_html: "" } }),
+          listComments: async () => ({ data: [] }),
+        },
+        repos: {
+          getCollaboratorPermissionLevel: async () => ({
+            data: { role_name: "admin" },
+          }),
+          getContent: async ({ path }: { path: string }) => {
+            if (path === CONFIG_FULL_PATH) {
+              return { data: "plugins:" };
+            }
+            return { data: null };
+          },
+        },
+      },
+    },
+    eventHandler: {
+      getAuthenticatedOctokit: () => createAuthenticatedOctokit(workflowDispatchCalls),
+    },
+  });
+
+  await issueCommentCreated(context);
+
+  assertEquals(workflowDispatchCalls.length, 0);
+});
+
+Deno.test("issueCommentCreated: routes mentions when config plugins is empty", async () => {
+  const fetchStub = stubFetch({
+    "https://router.test/v1/chat/completions": new Response(
+      JSON.stringify({
+        choices: [{ message: { content: JSON.stringify({ action: "ignore" }) } }],
+      }),
+      { headers: { "content-type": "application/json" } }
+    ),
+  });
+
+  const createCommentCalls: unknown[] = [];
+  const reactionCalls: unknown[] = [];
+  const context = createBaseContext("@ubiquityos should I use a command?", "User", {
+    octokit: {
+      rest: {
+        reactions: {
+          createForIssueComment: async (args: unknown) => {
+            reactionCalls.push(args);
+            return {};
+          },
+        },
+        issues: {
+          createComment: async (args: unknown) => {
+            createCommentCalls.push(args);
+            return {};
+          },
+          updateComment: async () => ({}),
+          get: async () => ({ data: { body: "", body_html: "" } }),
+          listComments: async () => ({ data: [] }),
+        },
+        repos: {
+          getCollaboratorPermissionLevel: async () => ({
+            data: { role_name: "admin" },
+          }),
+          getContent: async ({ path }: { path: string }) => {
+            if (path === CONFIG_FULL_PATH) {
+              return { data: "plugins:" };
+            }
+            return { data: null };
+          },
+        },
+      },
+    },
+    eventHandler: {
+      aiBaseUrl: "https://router.test",
+      llm: "test-model",
+    },
+  });
+
+  try {
+    await issueCommentCreated(context);
+  } finally {
+    fetchStub.restore();
+  }
+
+  assertEquals(reactionCalls.length, 1);
+  assertEquals(createCommentCalls.length, 0);
+});
+
 Deno.test("issueCommentCreated: dispatches internal agent for explicit human mention", async () => {
   const workflowDispatchCalls: unknown[] = [];
   const reactionCalls: unknown[] = [];


### PR DESCRIPTION
Fixes #287.

Addresses devpool-directory/devpool-directory#5926.

When YAML contains an empty `plugins:` key, the parsed config can have no plugin map. Issue comment command and mention routing both assumed that map was present, so they could throw while reading plugin entries.

This keeps the routing behavior unchanged when plugins exist, and treats a missing or empty plugin config as an empty plugin map.

Validation:
- `npx --yes deno test --allow-all tests/issue-comment-created.test.ts`
- `npx --yes deno check src/github/handlers/issue-comment-created.ts tests/issue-comment-created.test.ts`
- `git diff --check`