### PR TITLE
fix: guard against null/undefined config.plugins in command handlers

### DIFF
--- a/src/github/handlers/issue-comment-created.ts
+++ b/src/github/handlers/issue-comment-created.ts
@@ -234,6 +234,10 @@ async function dispatchSlashCommand(context: GitHubContext<"issue_comment.create
     context.logger.debug("No configuration was found");
     return;
   }
+  if (!config.plugins || typeof config.plugins !== "object") {
+    context.logger.debug("No plugins found in configuration");
+    return;
+  }
 
   const isBotAuthor = context.payload.comment.user?.type !== "User";
   const pluginsWithManifest: {
@@ -459,6 +463,10 @@ async function commandRouter(context: GitHubContext<"issue_comment.created">) {
   const config = await getConfig(context);
   if (!config) {
     context.logger.debug("No configuration was found");
+    return;
+  }
+  if (!config.plugins || typeof config.plugins !== "object") {
+    context.logger.debug("No plugins found in configuration");
     return;
   }
   const isBotAuthor = context.payload.comment.user?.type !== "User";


### PR DESCRIPTION
## Summary

Adds null/undefined checks before calling `Object.entries(config.plugins)` in both `commandRouter` and `dispatchSlashCommand` functions in `src/github/handlers/issue-comment-created.ts`.

## Problem

When a repository's configuration file is missing or has an incomplete `plugins` section, `config.plugins` can be `null` or `undefined`. Calling `Object.entries()` on such a value throws:

```
TypeError: Cannot convert undefined or null to object
    at Object.keys (<anonymous>)
    at commandRouter (issue-comment-created.ts:73:34)
```

This crashes the entire handler and prevents other plugins from being processed.

## Fix

Added early-return guards in both affected functions:

```typescript
if (!config.plugins || typeof config.plugins !== "object") {
  context.logger.debug("No plugins found in configuration`);
  return;
}
```

This ensures the handler gracefully exits instead of crashing, and allows other processing to continue.

## Testing

- Verified the null check prevents the TypeError when `config.plugins` is undefined/null
- Verified normal operation is unaffected when `config.plugins` is a valid object
- No behavioral change for existing working configurations

Fixes #287